### PR TITLE
CB-5699 [BlackBerry10] Update resolveLocalFileSystemURI implementation

### DIFF
--- a/src/blackberry10/index.js
+++ b/src/blackberry10/index.js
@@ -1,7 +1,7 @@
 module.exports = {
     setSandbox : function (success, fail, args, env) {
         require("lib/webview").setSandbox(JSON.parse(decodeURIComponent(args[0])));
-        new PluginResult(args, env).noResult(false);
+        new PluginResult(args, env).ok();
     },
 
     isSandboxed : function (success, fail, args, env) {

--- a/www/blackberry10/fileUtils.js
+++ b/www/blackberry10/fileUtils.js
@@ -47,6 +47,6 @@ module.exports = {
     },
 
     isOutsideSandbox: function (path) {
-        return (path.indexOf("accounts/1000/") === 0 || path.indexOf("/accounts/1000/") === 0);
+        return (path.indexOf("accounts/1000") !== -1);
     }
 };


### PR DESCRIPTION
The native webkitResolveLocalFileSystemURI does not support accessing URIs
outside of the application sandbox.

This isn't quite ready to merge. I still need to run some additional tests.
