### PR TITLE
remove redundant files dir in persistentRoot for android

### DIFF
--- a/src/android/FileUtils.java
+++ b/src/android/FileUtils.java
@@ -108,7 +108,7 @@ public class FileUtils extends CordovaPlugin {
     		location = "compatibility";
     	}
     	if ("internal".equalsIgnoreCase(location)) {
-    		persistentRoot = activity.getFilesDir().getAbsolutePath() + "/files/";
+    		persistentRoot = activity.getFilesDir().getAbsolutePath();
     		tempRoot = activity.getCacheDir().getAbsolutePath();
     		this.configured = true;
     	} else if ("compatibility".equalsIgnoreCase(location)) {


### PR DESCRIPTION
No need to concatenate "/files/" with `activity.getFilesDir().getAbsolutePath()`, since it seems like this would be like doing: `tempRoot = activity.getCacheDir().getAbsolutePath() + "/cache/"` ?
