### PR TITLE
Update CDVLocalFilesystem.m

### DIFF
--- a/src/ios/CDVLocalFilesystem.m
+++ b/src/ios/CDVLocalFilesystem.m
@@ -536,8 +536,8 @@
     }
 
     else if ([srcFs isKindOfClass:[CDVLocalFilesystem class]]) {
-        /* Same FS, we can shortcut with NSFileManager operations */
-        NSString *srcFullPath = [self filesystemPathForURL:srcURL];
+        /* Same FS Type, we can shortcut with NSFileManager operations */
+        NSString *srcFullPath = [srcFs filesystemPathForURL:srcURL];
 
         BOOL bSrcIsDir = NO;
         BOOL bSrcExists = [fileMgr fileExistsAtPath:srcFullPath isDirectory:&bSrcIsDir];


### PR DESCRIPTION
srcFullPath should derive from srcFS in order to copy from temporary to persistent storage.
I'm not sure if [self canCopyMoveSrc:srcFullPath ...] should be changed as well?
