### PR TITLE
fix the Windows 8 implementation of the getFile method

### DIFF
--- a/src/windows8/FileProxy.js
+++ b/src/windows8/FileProxy.js
@@ -376,9 +376,20 @@ module.exports = {
     },
 
     getFile:function(win,fail,args) {
-        var fullPath = args[0];
-        var path = args[1];
+		//not sure why, but it won't work with normal slashes...
+		var fullPath = args[0].replace(/\//g, '\\');
+        var path = args[1].replace(/\//g, '\\');
         var options = args[2];
+
+        var completePath = fullPath + '\\' + path;
+		//handles trailing slash and leading slash, or just one or the other
+        completePath = completePath.replace(/\\\\\\/g, '/').replace(/\\\\/g, '\\');
+
+        var fileName = completePath.substring(completePath.lastIndexOf('\\'));
+		
+		//final adjustment
+        fullPath = completePath.substring(0, completePath.lastIndexOf('\\'));
+        path = fileName.replace(/\\/g, '');
 
         var flag = "";
         if (options !== null) {


### PR DESCRIPTION
The storageFolder.getFileAsync(name) does not accept relative paths, only a simple file name...
see http://msdn.microsoft.com/en-us/library/windows/apps/windows.storage.storagefolder.getfileasync?cs-save-lang=1&cs-lang=javascript#code-snippet-1

I didn't check, but other methods might be affected similarly...
(accepting a relative path, but using methods only accepting a name)
