### PR TITLE
Fix getFreeDiskSpace on iOS to return the actual complete free space

### DIFF
--- a/src/ios/CDVFile.m
+++ b/src/ios/CDVFile.m
@@ -1010,8 +1010,8 @@ NSString* const kCDVFilesystemURLPrefix = @"cdvfile";
 - (void)getFreeDiskSpace:(CDVInvokedUrlCommand*)command
 {
     // no arguments
-
-    NSNumber* pNumAvail = [self checkFreeDiskSpace:self.appDocsPath];
+    NSString* fullPath = @"/";
+    NSNumber* pNumAvail = [self checkFreeDiskSpace:fullPath];
 
     NSString* strFreeSpace = [NSString stringWithFormat:@"%qu", [pNumAvail unsignedLongLongValue]];
     // NSLog(@"Free space is %@", strFreeSpace );


### PR DESCRIPTION
On iOS, checkFreeDiskSpace returns 0 for appDocsPath.
We need to check free space on /.
