### PR TITLE
Fix mis-handling of filesystem reference in Entry.moveTo

### DIFF
--- a/www/Entry.js
+++ b/www/Entry.js
@@ -145,7 +145,8 @@ Entry.prototype.copyTo = function(parent, newName, successCallback, errorCallbac
     var fail = errorCallback && function(code) {
         errorCallback(new FileError(code));
     };
-    var srcURL = this.toInternalURL(),
+    var filesystem = this.filesystem, 
+        srcURL = this.toInternalURL(),
         // entry name
         name = newName || this.name,
         // success callback
@@ -153,7 +154,7 @@ Entry.prototype.copyTo = function(parent, newName, successCallback, errorCallbac
             if (entry) {
                 if (successCallback) {
                     // create appropriate Entry object
-                    var fs = entry.filesystemName ? new FileSystem(entry.filesystemName, {name:"", fullPath:"/"}) : this.filesystem;
+                    var fs = entry.filesystemName ? new FileSystem(entry.filesystemName, {name:"", fullPath:"/"}) : filesystem;
                     var result = (entry.isDirectory) ? new (require('./DirectoryEntry'))(entry.name, entry.fullPath, fs, entry.nativeURL) : new (require('org.apache.cordova.file.FileEntry'))(entry.name, entry.fullPath, fs, entry.nativeURL);
                     successCallback(result);
                 }


### PR DESCRIPTION
`this` was mistakenly used inside a closure in `Entry.moveTo`.  If no `entry.filesystemName` was provided, then the original filesystem reference was dropped.
