### PR TITLE
fix for CB-6872

### DIFF
--- a/src/ios/CDVFile.m
+++ b/src/ios/CDVFile.m
@@ -426,7 +426,7 @@ NSString* const kCDVFilesystemURLPrefix = @"cdvfile";
     } else {
         NSString* fullPath = @"/";
         // check for avail space for size request
-        NSNumber* pNumAvail = [self checkFreeDiskSpace:fullPath];
+        NSNumber* pNumAvail = [self checkFreeDiskSpace:self.rootDocsPath];
         // NSLog(@"Free space: %@", [NSString stringWithFormat:@"%qu", [ pNumAvail unsignedLongLongValue ]]);
         if (pNumAvail && ([pNumAvail unsignedLongLongValue] < size)) {
             result = [CDVPluginResult resultWithStatus:CDVCommandStatus_IO_EXCEPTION messageAsInt:QUOTA_EXCEEDED_ERR];


### PR DESCRIPTION
This Pull Request fix CB-6872
the free space available wasn't returning the right value, so when you request the file system with a high value it fails with QUOTA_EXCEEDED_ERR
https://issues.apache.org/jira/browse/CB-6872

var requestBytes = 300 \* 1024 \* 1024; // 300MB
window.requestFileSystem(LocalFileSystem.PERSISTENT, requestBytes, function(fs) {
                                 alert("success");
                                 }, function (e) {
                                 // error callback
                                 alert("error");
                                 });

This code was failing on my ipod touch 32GB with 7+GB free, and now I can request the 7GB

The problem is, checking the free space doesn't return the actual available free space when you use the root path "/",
you have to use another path instead, like self.rootDocsPath (documents folder path) to get the actual free available space. I tried some other paths and all of them worked ("/var", "/var/mobile/") but used self.rootDocsPath because it was already declared on the code so I didn't have to hardcode a path.
With paths like "/", "/etc" it returns the same wrong value.
