### PR TITLE
CB-6980 Fixing filesystem:null property in Entry

### DIFF
--- a/www/resolveLocalFileSystemURI.js
+++ b/www/resolveLocalFileSystemURI.js
@@ -53,8 +53,8 @@ module.exports.resolveLocalFileSystemURL = function(uri, successCallback, errorC
                 var fsName = entry.filesystemName || (entry.filesystem == window.PERSISTENT ? 'persistent' : 'temporary');
                 fileSystems.getFs(fsName, function(fs) {
                     if (!fs) {
-						fs = new FileSystem(fsName, {name:"", fullPath:"/"});
-					}
+                        fs = new FileSystem(fsName, {name:"", fullPath:"/"});
+                    }
                     var result = (entry.isDirectory) ? new DirectoryEntry(entry.name, entry.fullPath, fs, entry.nativeURL) : new FileEntry(entry.name, entry.fullPath, fs, entry.nativeURL);
                     successCallback(result);
                 });


### PR DESCRIPTION
when resolveLocalFileSystemURI or resolveLocalFileSystemURL is called on
the File Plugin under Windows Phone 8, on success it should return a
Entry with several properties, as it is the filesystem information,
which returns as null.
on resolveLocalFileSystemURI.js it calls fileSystem.getFS the object
retrieved it should contain the filesystem information.
Since the fix, CB-6525, only adds support for Android and iOS, for other
platform it retrieves a null object, so adding a condition to retrieve
the information if the object from the callback is null.
