### PR TITLE
CB-6532 iOS: a cdvfile:// to a CSS file doesn't work in a link tag

### DIFF
--- a/src/ios/CDVAssetLibraryFilesystem.m
+++ b/src/ios/CDVAssetLibraryFilesystem.m
@@ -96,6 +96,8 @@ NSString* const kCDVAssetsLibraryScheme = @"assets-library";
                     mimeType = @"audio/mp4";
                 } else if ([[fullPath pathExtension] rangeOfString:@"wav"].location != NSNotFound) {
                     mimeType = @"audio/wav";
+                } else if ([[fullPath pathExtension] rangeOfString:@"css"].location != NSNotFound) {
+                    mimeType = @"text/css";
                 }
             }
             CFRelease(typeId);

--- a/src/ios/CDVLocalFilesystem.m
+++ b/src/ios/CDVLocalFilesystem.m
@@ -639,6 +639,8 @@
                     mimeType = @"audio/mp4";
                 } else if ([[fullPath pathExtension] rangeOfString:@"wav"].location != NSNotFound) {
                     mimeType = @"audio/wav";
+                } else if ([[fullPath pathExtension] rangeOfString:@"css"].location != NSNotFound) {
+                    mimeType = @"text/css";
                 }
             }
             CFRelease(typeId);


### PR DESCRIPTION
The issue is that there's a bug in UTTypeCopyPreferredTagWithClass, It returns nil mimetype for css (sometimes -- it appears that it happens when there is no network).  There is already a workaround for other files -- the JIRA case indicates that this might be true for fonts as well.
