### PR TITLE
[CB- 7057] Improve File API documentation, especially wrt to cordova.file.* properties

### DIFF
--- a/doc/index.md
+++ b/doc/index.md
@@ -322,21 +322,21 @@ filesystems to be installed. By default, all file-system roots are enabled.
 
 ### Android
 
-* files: The application's internal file storage directory
-* files-external: The application's external file storage directory
-* sdcard: The global external file storage directory (this is the root of the SD card, if one is installed). You must have the `android.permission.WRITE_EXTERNAL_STORAGE` permission to use this.
-* cache: The application's internal cache directory
-* cache-external: The application's external cache directory
-* root: The entire device filesystem
+* `files`: The application's internal file storage directory
+* `files-external`: The application's external file storage directory
+* `sdcard`: The global external file storage directory (this is the root of the SD card, if one is installed). You must have the `android.permission.WRITE_EXTERNAL_STORAGE` permission to use this.
+* `cache`: The application's internal cache directory
+* `cache-external`: The application's external cache directory
+* `root`: The entire device filesystem
 
 Android also supports a special filesystem named "documents", which represents a "/Documents/" subdirectory within the "files" filesystem.
 
 ### iOS
 
-* library: The application's Library directory
-* documents: The application's Documents directory
-* cache: The application's Cache directory
-* bundle: The application's bundle; the location of the app itself on disk (read-only)
-* root: The entire device filesystem
+* `library`: The application's Library directory
+* `documents`: The application's Documents directory
+* `cache`: The application's Cache directory
+* `bundle`: The application's bundle; the location of the app itself on disk (read-only)
+* `root`: The entire device filesystem
 
 By default, the library and documents directories can be synced to iCloud. You can also request two additional filesystems, `library-nosync` and `documents-nosync`, which represent a special non-synced directory within the `/Library` or `/Documents` filesystem.


### PR DESCRIPTION
As discussed on the google groups, the documentation for the `cordova.file.*` properties is unclear (see post: https://groups.google.com/forum/#!topic/phonegap/W1ZR6WG5XwM). Revised documentation to make it clearer, and also added a table indicating how the properties relate to the file system and the various properties on each path (read-write, private, etc.)

Bug # is CB-7057.
