### PR TITLE
Overwrite existing file on getFile when create is true

### DIFF
--- a/src/firefoxos/FileProxy.js
+++ b/src/firefoxos/FileProxy.js
@@ -136,7 +136,19 @@ QUIRKS:
                 idb_.put(newFileEntry, path.storagePath, successCallback, errorCallback);
             } else if (options.create === true && fileEntry) {
                 if (fileEntry.isFile) {
-                    successCallback(fileEntryFromIdbEntry(fileEntry));
+                    // Overwrite file, delete then create new.
+                    idb_['delete'](path.storagePath, function() {
+                        var newFileEntry = new FileEntry(path.fileName, path.fullPath, new FileSystem(path.fsName, fs_.root));
+
+                        newFileEntry.file_ = new MyFile({
+                            size: 0,
+                            name: newFileEntry.name,
+                            lastModifiedDate: new Date(),
+                            storagePath: path.storagePath
+                        });
+
+                        idb_.put(newFileEntry, path.storagePath, successCallback, errorCallback);
+                    }, errorCallback);
                 } else {
                     if (errorCallback) {
                         errorCallback(FileError.INVALID_MODIFICATION_ERR);


### PR DESCRIPTION
Realized that this is the expected behavior when playing with the [phonegap developer app](https://github.com/phonegap/phonegap-app-developer/blob/f23f53db780c2be3ce4a6388d6b2c731bc0802a1/www/js/app.js#L147-L179).
