### PR TITLE
[CB-7418][DirectoryEntry] Added fullPath variable as part of condition

### DIFF
--- a/www/DirectoryEntry.js
+++ b/www/DirectoryEntry.js
@@ -38,7 +38,7 @@ var argscheck = require('cordova/argscheck'),
 var DirectoryEntry = function(name, fullPath, fileSystem, nativeURL) {
 
     // add trailing slash if it is missing
-    if (!/\/$/.test(fullPath)) {
+    if ((fullPath) && !/\/$/.test(fullPath)) {
         fullPath += "/";
     }
     // add trailing slash if it is missing


### PR DESCRIPTION
As well as nativeUrl property, the fullPath variable should be part of the condition to avoid that a null value becoming a path, by adding a slash at the end of the undefined string, resulting in 'undefined/'.

So in order to add a slash to it, fullPath should contain a value.
