### PR TITLE
[CB-7375] Remove leading slash statement from condition

### DIFF
--- a/www/resolveLocalFileSystemURI.js
+++ b/www/resolveLocalFileSystemURI.js
@@ -40,7 +40,7 @@ module.exports.resolveLocalFileSystemURL = function(uri, successCallback, errorC
     };
     // sanity check for 'not:valid:filename' or '/not:valid:filename'
     // file.spec.12 window.resolveLocalFileSystemURI should error (ENCODING_ERR) when resolving invalid URI with leading /.
-    if(!uri || uri.split(":").length > 2 || uri.indexOf('/') == 0) {
+    if(!uri || uri.split(":").length > 2) {
         setTimeout( function() {
             fail(FileError.ENCODING_ERR);
         },0);


### PR DESCRIPTION
Windows Phone file paths starts with a leading slash, if the path is an invalid one, the native side it will report a error callback with the respective error code.
