### PR TITLE
[CB-7375][Entry] set proper filesystem in Entry, when moveTo or copyTo

### DIFF
--- a/www/Entry.js
+++ b/www/Entry.js
@@ -118,7 +118,7 @@ Entry.prototype.moveTo = function(parent, newName, successCallback, errorCallbac
                 if (successCallback) {
                     // create appropriate Entry object
                     var newFSName = entry.filesystemName || (entry.filesystem && entry.filesystem.name);
-                    var fs = (newFSName && new FileSystem(newFSName, { name: "", fullPath: "/" }));
+                    var fs = newFSName ? new FileSystem(newFSName, { name: "", fullPath: "/" }) : new FileSystem(parent.filesystem.name, { name: "", fullPath: "/" });
                     var result = (entry.isDirectory) ? new (require('./DirectoryEntry'))(entry.name, entry.fullPath, fs, entry.nativeURL) : new (require('org.apache.cordova.file.FileEntry'))(entry.name, entry.fullPath, fs, entry.nativeURL);
                     successCallback(result);
                 }
@@ -160,7 +160,7 @@ Entry.prototype.copyTo = function(parent, newName, successCallback, errorCallbac
                 if (successCallback) {
                     // create appropriate Entry object
                     var newFSName = entry.filesystemName || (entry.filesystem && entry.filesystem.name);
-                    var fs = (newFSName && new FileSystem(newFSName, { name: "", fullPath: "/" }));
+                    var fs = newFSName ? new FileSystem(newFSName, { name: "", fullPath: "/" }) : new FileSystem(parent.filesystem.name, { name: "", fullPath: "/" });
                     var result = (entry.isDirectory) ? new (require('./DirectoryEntry'))(entry.name, entry.fullPath, fs, entry.nativeURL) : new (require('org.apache.cordova.file.FileEntry'))(entry.name, entry.fullPath, fs, entry.nativeURL);
                     successCallback(result);
                 }


### PR DESCRIPTION
When the native side it doesn't return any kind of value related directly related with the fileSystem, it has to be recreated after a copy, however, it makes perfect sense, that when the entry for the copied or moved file if there's no value in entry.fileSystem, it takes the filesystem property from the parent directory that it has been moved to or copied to. So instead of return a null object or take the previous filesystem(origin) from wherever location it was copied or moved from. It would be better take the parent filesystem name and recreate it.
