### PR TITLE
[CB-7422][File Tests] Use proper fileSystem to create fullPath

### DIFF
--- a/tests/tests.js
+++ b/tests/tests.js
@@ -2921,7 +2921,7 @@ exports.defineAutoTests = function () {
                 var file1 = "entry.copy.file1b",
                 file2 = "entry.copy.file2b",
                 sourceEntry,
-                fullPath = joinURL(root.fullPath, file2),
+                fullPath = joinURL(temp_root.fullPath, file2),
                 validateFile = function (entry) {
                     expect(entry).toBeDefined();
                     expect(entry.isFile).toBe(true);
@@ -2990,7 +2990,7 @@ exports.defineAutoTests = function () {
                 var file1 = "entry.copy.file1b",
                 file2 = "entry.copy.file2b",
                 sourceEntry,
-                fullPath = joinURL(root.fullPath, file2),
+                fullPath = joinURL(temp_root.fullPath, file2),
                 validateFile = function (entry) {
                     expect(entry).toBeDefined();
                     expect(entry.isFile).toBe(true);


### PR DESCRIPTION
The filesystem uses root filesystem (PERSISTENT) to compare with a TEMPORARY filesystem.
This is wrong, if TEMPORARY, var 'temp_root' should be used to assign value to fullPath.
Tested over android & WP8, everything OK.

This wasn't caught before, because android : 
fullPath is: /file, and (root.fullPath + file) returns ---> /file.
although for Windows Phone: the fullPath provides the nativePath as /tmp//file, when it tries to compare with (root.fullPath + file) gives //file. But tmp_root.fullPath provides the right path: /tmp/ to compare with.

Android it doesn't provide any different fullPath property if temporary or persistent, the right path it's contained over the Native or Internal path.
