### PR TITLE
CB-7423 encode path before attempting to resolve

### DIFF
--- a/src/ios/CDVFile.m
+++ b/src/ios/CDVFile.m
@@ -538,6 +538,8 @@ NSString* const kCDVFilesystemURLPrefix = @"cdvfile";
     // arguments
     NSString* localURIstr = [command.arguments objectAtIndex:0];
     CDVPluginResult* result;
+    
+    localURIstr = [self encodePath:localURIstr]; //encode path before resolving
     CDVFilesystemURL* inputURI = [self fileSystemURLforArg:localURIstr];
     
     if (inputURI == nil || inputURI.fileSystemName == nil) {
@@ -551,6 +553,13 @@ NSString* const kCDVFilesystemURLPrefix = @"cdvfile";
         }
     }
     [self.commandDelegate sendPluginResult:result callbackId:command.callbackId];
+}
+
+//encode path with percent escapes
+-(NSString *)encodePath:(NSString *)path
+{
+    NSString *decodedPath = [path stringByReplacingPercentEscapesUsingEncoding:NSUTF8StringEncoding]; //decode incase it's already encoded to avoid encoding twice
+    return [decodedPath stringByAddingPercentEscapesUsingEncoding:NSUTF8StringEncoding];
 }
 
 


### PR DESCRIPTION
For some of the tests in mobilespec, files aren't getting deleted at cleanup so you get a PATH_EXISTS error on the second run. The files are not getting deleted because the URI is not getting resolved on the native side. The files are not getting resolved because whitespace in the path is not getting encoded before attempting to resolve.
