### PR TITLE
[fxos] update __format__ to match pathsPrefix

### DIFF
--- a/www/firefoxos/FileSystem.js
+++ b/www/firefoxos/FileSystem.js
@@ -19,7 +19,7 @@
  *
 */
 
-FILESYSTEM_PREFIX = "cdvfile://";
+FILESYSTEM_PREFIX = "file:///";
 
 module.exports = {
     __format__: function(fullPath) {


### PR DESCRIPTION
Noticed this while implementing new functionality on PG dev app. The filesystem prefix should match what we have in [pathsPrefix](https://github.com/rodms10/cordova-plugin-file/blob/master/src/firefoxos/FileProxy.js#L60).

@zalun, can you please take a look?
