### PR TITLE
Rework to use normal url form on windows platform

### DIFF
--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -275,3 +275,21 @@
 * CB-6923 Adding support to handle relative paths
 * Style improvements on Manual tests
 * CB-7094 Ported File manual tests
+
+### 1.3.2 (Dec 02, 2014)
+* Gets rid of thread block error in File plugin
+* CB-7917 Made tests file.spec.114 - 116 pass for **Windows** platform
+* CB-7977 Mention `deviceready` in plugin docs
+* CB-7602: Fix `isCopyOnItself` logic
+* CB-7700 cordova-plugin-file documentation translation: cordova-plugin-file
+* Use one proxy for both **Windows** and **Windows8** platforms
+* CB-6994 Fixes result, returned by proxy's write method
+* [fxos] update `__format__` to match `pathsPrefix`
+* CB-6994 Improves merged code to be able to write a File
+* Optimize `FileProxy` for **Windows** platforms
+* Synchronize changes with **Windows** platform
+* Fix function write for big files on **Windows 8**
+* Write file in background
+* CB-7487 **Android** Broadcast file write This allows MTP USB shares to show the file immediately without reboot/manual refresh using 3rd party app.
+* CB-7700 cordova-plugin-file documentation translation: cordova-plugin-file
+* CB-7571 Bump version of nested plugin to match parent plugin

--- a/doc/index.md
+++ b/doc/index.md
@@ -40,6 +40,15 @@ For usage, please refer to HTML5 Rocks' excellent [FileSystem article.](http://w
 For an overview of other storage options, refer to Cordova's
 [storage guide](http://cordova.apache.org/docs/en/edge/cordova_storage_storage.md.html).
 
+This plugin defines global `cordova.file` object.
+
+Although in the global scope, it is not available until after the `deviceready` event.
+
+    document.addEventListener("deviceready", onDeviceReady, false);
+    function onDeviceReady() {
+        console.log(cordova.file);
+    }
+
 ## Installation
 
     cordova plugin add org.apache.cordova.file

--- a/plugin.xml
+++ b/plugin.xml
@@ -21,7 +21,7 @@
 <plugin xmlns="http://apache.org/cordova/ns/plugins/1.0"
 xmlns:android="http://schemas.android.com/apk/res/android"
            id="org.apache.cordova.file"
-      version="1.3.2">
+      version="1.3.3-dev">
     <name>File</name>
     <description>Cordova File Plugin</description>
     <license>Apache 2.0</license>

--- a/plugin.xml
+++ b/plugin.xml
@@ -21,7 +21,7 @@
 <plugin xmlns="http://apache.org/cordova/ns/plugins/1.0"
 xmlns:android="http://schemas.android.com/apk/res/android"
            id="org.apache.cordova.file"
-      version="1.3.2-dev">
+      version="1.3.2">
     <name>File</name>
     <description>Cordova File Plugin</description>
     <license>Apache 2.0</license>

--- a/src/android/ContentFilesystem.java
+++ b/src/android/ContentFilesystem.java
@@ -73,11 +73,7 @@ public class ContentFilesystem extends Filesystem {
 	@Override
 	public JSONObject getEntryForLocalURL(LocalFilesystemURL inputURL) throws IOException {
 	    if ("/".equals(inputURL.fullPath)) {
-            try {
-                return LocalFilesystem.makeEntryForURL(inputURL, true, inputURL.URL.toString());
-            } catch (JSONException e) {
-                throw new IOException();
-            }
+            return LocalFilesystem.makeEntryForURL(inputURL, true, inputURL.URL.toString());
 	    }
 
 		// Get the cursor to validate that the file exists
@@ -97,11 +93,7 @@ public class ContentFilesystem extends Filesystem {
 		} else {
 			filePath = "file://" + filePath;
 		}
-		try {
-			return makeEntryForPath(inputURL.fullPath, inputURL.filesystemName, false /*fp.isDirectory()*/, filePath);
-		} catch (JSONException e) {
-			throw new IOException();
-		}
+        return makeEntryForPath(inputURL.fullPath, inputURL.filesystemName, false /*fp.isDirectory()*/, filePath);
 	}
 	
     @Override

--- a/src/android/ContentFilesystem.java
+++ b/src/android/ContentFilesystem.java
@@ -46,8 +46,8 @@ public class ContentFilesystem extends Filesystem {
 	private CordovaInterface cordova;
 	private CordovaResourceApi resourceApi;
 	
-	public ContentFilesystem(String name, CordovaInterface cordova, CordovaWebView webView) {
-		this.name = name;
+	public ContentFilesystem(CordovaInterface cordova, CordovaWebView webView) {
+		super(Uri.parse("content://"), "content");
 		this.cordova = cordova;
 
 		Class webViewClass = webView.getClass();

--- a/src/android/FileUtils.java
+++ b/src/android/FileUtils.java
@@ -219,6 +219,10 @@ public class FileUtils extends CordovaPlugin {
     
     @Override
     public Uri remapUri(Uri uri) {
+        // Remap only cdvfile: URLs (not content:).
+        if (!LocalFilesystemURL.FILESYSTEM_PROTOCOL.equals(uri.getScheme())) {
+            return null;
+        }
         try {
         	LocalFilesystemURL inputURL = new LocalFilesystemURL(uri);
         	Filesystem fs = this.filesystemForURL(inputURL);
@@ -227,7 +231,7 @@ public class FileUtils extends CordovaPlugin {
         	}
         	String path = fs.filesystemPathForURL(inputURL);
         	if (path != null) {
-        		return Uri.parse("file:///" + fs.filesystemPathForURL(inputURL));
+        		return Uri.parse("file://" + fs.filesystemPathForURL(inputURL));
         	}
         	return null;
         } catch (IllegalArgumentException e) {

--- a/src/android/FileUtils.java
+++ b/src/android/FileUtils.java
@@ -112,10 +112,10 @@ public class FileUtils extends CordovaPlugin {
                 if (fsRoot != null) {
                     File newRoot = new File(fsRoot);
                     if (newRoot.mkdirs() || newRoot.isDirectory()) {
-                        registerFilesystem(new LocalFilesystem(fsName, cordova, fsRoot));
+                        registerFilesystem(new LocalFilesystem(fsName, cordova, Uri.fromFile(newRoot)));
                         installedFileSystems.add(fsName);
                     } else {
-                       Log.d(LOG_TAG, "Unable to create root dir for fileystem \"" + fsName + "\", skipping");
+                       Log.d(LOG_TAG, "Unable to create root dir for filesystem \"" + fsName + "\", skipping");
                     }
                 } else {
                     Log.d(LOG_TAG, "Unrecognized extra filesystem identifier: " + fsName);
@@ -194,7 +194,7 @@ public class FileUtils extends CordovaPlugin {
     		// per spec.
     		this.registerFilesystem(new LocalFilesystem("temporary", cordova, tempRoot));
     		this.registerFilesystem(new LocalFilesystem("persistent", cordova, persistentRoot));
-    		this.registerFilesystem(new ContentFilesystem("content", cordova, webView));
+    		this.registerFilesystem(new ContentFilesystem(cordova, webView));
 
             registerExtraFileSystems(getExtraFileSystemsPreference(activity), getAvailableFileSystems(activity));
 
@@ -849,10 +849,8 @@ public class FileUtils extends CordovaPlugin {
         if (rootFs == null) {
             throw new IOException("No filesystem of type requested");        	
         }
-        LocalFilesystemURL rootURL = new LocalFilesystemURL(LocalFilesystemURL.FILESYSTEM_PROTOCOL + "://localhost/"+rootFs.name+"/");
-
         fs.put("name", rootFs.name);
-        fs.put("root", rootFs.getEntryForLocalURL(rootURL));
+        fs.put("root", rootFs.getRootEntry());
         return fs;
     }
 
@@ -868,8 +866,7 @@ public class FileUtils extends CordovaPlugin {
     private JSONArray requestAllFileSystems() throws IOException, JSONException {
         JSONArray ret = new JSONArray();
         for (Filesystem fs : filesystems) {
-            LocalFilesystemURL rootURL = new LocalFilesystemURL(LocalFilesystemURL.FILESYSTEM_PROTOCOL + "://localhost/"+fs.name+"/");
-            ret.put(fs.getEntryForLocalURL(rootURL));
+            ret.put(fs.getRootEntry());
         }
         return ret;
     }

--- a/src/android/Filesystem.java
+++ b/src/android/Filesystem.java
@@ -18,6 +18,8 @@
  */
 package org.apache.cordova.file;
 
+import android.net.Uri;
+
 import java.io.File;
 import java.io.FileNotFoundException;
 import java.io.FilterInputStream;
@@ -31,9 +33,17 @@ import org.json.JSONObject;
 
 public abstract class Filesystem {
 
-	public String name;
-	
-	public interface ReadFileCallback {
+    protected final Uri rootUri;
+    public final String name;
+    private final JSONObject rootEntry;
+
+    public Filesystem(Uri rootUri, String name) {
+        this.rootUri = rootUri;
+        this.name = name;
+        rootEntry = makeEntryForPath("/", name, true, rootUri.toString());
+    }
+
+    public interface ReadFileCallback {
 		public void handleData(InputStream inputStream, String contentType) throws IOException;
 	}
 
@@ -81,6 +91,14 @@ public abstract class Filesystem {
 	abstract JSONArray readEntriesAtLocalURL(LocalFilesystemURL inputURL) throws FileNotFoundException;
 
 	abstract JSONObject getFileMetadataForLocalURL(LocalFilesystemURL inputURL) throws FileNotFoundException;
+
+    public Uri getRootUri() {
+        return rootUri;
+    }
+
+    public JSONObject getRootEntry() {
+        return rootEntry;
+    }
 
 	public JSONObject getParentForLocalURL(LocalFilesystemURL inputURL) throws IOException {
 		LocalFilesystemURL newURL = new LocalFilesystemURL(inputURL.URL);

--- a/src/android/Filesystem.java
+++ b/src/android/Filesystem.java
@@ -37,31 +37,35 @@ public abstract class Filesystem {
 		public void handleData(InputStream inputStream, String contentType) throws IOException;
 	}
 
-	public static JSONObject makeEntryForPath(String path, String fsName, Boolean isDir, String nativeURL)
-			throws JSONException {
-        JSONObject entry = new JSONObject();
+	public static JSONObject makeEntryForPath(String path, String fsName, Boolean isDir, String nativeURL) {
+        try {
+            JSONObject entry = new JSONObject();
 
-        int end = path.endsWith("/") ? 1 : 0;
-        String[] parts = path.substring(0,path.length()-end).split("/+");
-        String fileName = parts[parts.length-1];
-        entry.put("isFile", !isDir);
-        entry.put("isDirectory", isDir);
-        entry.put("name", fileName);
-        entry.put("fullPath", path);
-        // The file system can't be specified, as it would lead to an infinite loop,
-        // but the filesystem name can be.
-        entry.put("filesystemName", fsName);
-        // Backwards compatibility
-        entry.put("filesystem", "temporary".equals(fsName) ? 0 : 1);
+            int end = path.endsWith("/") ? 1 : 0;
+            String[] parts = path.substring(0, path.length() - end).split("/+");
+            String fileName = parts[parts.length - 1];
+            entry.put("isFile", !isDir);
+            entry.put("isDirectory", isDir);
+            entry.put("name", fileName);
+            entry.put("fullPath", path);
+            // The file system can't be specified, as it would lead to an infinite loop,
+            // but the filesystem name can be.
+            entry.put("filesystemName", fsName);
+            // Backwards compatibility
+            entry.put("filesystem", "temporary".equals(fsName) ? 0 : 1);
 
-        if (isDir && !nativeURL.endsWith("/")) {
-            nativeURL += "/";
+            if (isDir && !nativeURL.endsWith("/")) {
+                nativeURL += "/";
+            }
+            entry.put("nativeURL", nativeURL);
+            return entry;
+        } catch (JSONException e) {
+            e.printStackTrace();
+            throw new RuntimeException(e);
         }
-    	entry.put("nativeURL", nativeURL);
-        return entry;
     }
 
-    public static JSONObject makeEntryForURL(LocalFilesystemURL inputURL, Boolean isDir, String nativeURL) throws JSONException {
+    public static JSONObject makeEntryForURL(LocalFilesystemURL inputURL, Boolean isDir, String nativeURL) {
         return makeEntryForPath(inputURL.fullPath, inputURL.filesystemName, isDir, nativeURL);
     }
 

--- a/src/android/LocalFilesystem.java
+++ b/src/android/LocalFilesystem.java
@@ -44,17 +44,18 @@ import android.app.Activity;
 
 public class LocalFilesystem extends Filesystem {
 
-	private String fsRoot;
 	private CordovaInterface cordova;
 
-	public LocalFilesystem(String name, CordovaInterface cordova, String fsRoot) {
-		this.name = name;
-		this.fsRoot = fsRoot;
+    public LocalFilesystem(String name, CordovaInterface cordova, String rootPath) {
+        this(name, cordova, Uri.fromFile(new File(rootPath)));
+    }
+	public LocalFilesystem(String name, CordovaInterface cordova, Uri rootUri) {
+        super(rootUri, name);
 		this.cordova = cordova;
 	}
 
-	public String filesystemPathForFullPath(String fullPath) {
-	    String path = new File(this.fsRoot, fullPath).toString();
+    public String filesystemPathForFullPath(String fullPath) {
+	    String path = new File(rootUri.getPath(), fullPath).toString();
         int questionMark = path.indexOf("?");
         if (questionMark >= 0) {
           path = path.substring(0, questionMark);
@@ -71,8 +72,8 @@ public class LocalFilesystem extends Filesystem {
 	}
 
 	private String fullPathForFilesystemPath(String absolutePath) {
-		if (absolutePath != null && absolutePath.startsWith(this.fsRoot)) {
-			return absolutePath.substring(this.fsRoot.length());
+		if (absolutePath != null && absolutePath.startsWith(rootUri.getPath())) {
+			return absolutePath.substring(rootUri.getPath().length());
 		}
 		return null;
 	}
@@ -288,10 +289,6 @@ public class LocalFilesystem extends Filesystem {
     /**
      * Check to see if the user attempted to copy an entry into its parent without changing its name,
      * or attempted to copy a directory into a directory that it contains directly or indirectly.
-     *
-     * @param srcDir
-     * @param destinationDir
-     * @return
      */
     private boolean isCopyOnItself(String src, String dest) {
 

--- a/src/android/LocalFilesystem.java
+++ b/src/android/LocalFilesystem.java
@@ -305,11 +305,7 @@ public class LocalFilesystem extends Filesystem {
         // This weird test is to determine if we are copying or moving a directory into itself.
         // Copy /sdcard/myDir to /sdcard/myDir-backup is okay but
         // Copy /sdcard/myDir to /sdcard/myDir/backup should throw an INVALID_MODIFICATION_ERR
-        if (dest.startsWith(src) && dest.indexOf(File.separator, src.length() - 1) != -1) {
-            return true;
-        }
-
-        return false;
+        return dest.equals(src) || dest.startsWith(src + File.separator);
     }
 
     /**

--- a/src/android/LocalFilesystem.java
+++ b/src/android/LocalFilesystem.java
@@ -143,11 +143,7 @@ public class LocalFilesystem extends Filesystem {
       if (!fp.canRead()) {
           throw new IOException();
       }
-      try {
-          return LocalFilesystem.makeEntryForURL(inputURL, fp.isDirectory(),  Uri.fromFile(fp).toString());
-      } catch (JSONException e) {
-    	  throw new IOException();
-      }
+      return LocalFilesystem.makeEntryForURL(inputURL, fp.isDirectory(),  Uri.fromFile(fp).toString());
 	}
 
 	@Override
@@ -259,10 +255,7 @@ public class LocalFilesystem extends Filesystem {
             File[] files = fp.listFiles();
             for (int i = 0; i < files.length; i++) {
                 if (files[i].canRead()) {
-                    try {
-						entries.put(makeEntryForPath(fullPathForFilesystemPath(files[i].getAbsolutePath()), inputURL.filesystemName, files[i].isDirectory(), Uri.fromFile(files[i]).toString()));
-					} catch (JSONException e) {
-					}
+                    entries.put(makeEntryForPath(fullPathForFilesystemPath(files[i].getAbsolutePath()), inputURL.filesystemName, files[i].isDirectory(), Uri.fromFile(files[i]).toString()));
                 }
             }
         }

--- a/src/windows/FileProxy.js
+++ b/src/windows/FileProxy.js
@@ -62,9 +62,7 @@ function cordovaPathToNative(path) {
     // turn / into \\
     var cleanPath = path.replace(/\//g, '\\');
     // turn  \\ into \
-    cleanPath = cleanPath.replace(/\\\\/g, '\\');
-    // strip end \\ characters
-    cleanPath = cleanPath.replace(/\\+$/g, '');
+    cleanPath = cleanPath.replace(/\\+/g, '\\');
     return cleanPath;
 }
 
@@ -151,7 +149,7 @@ function getFilesystemFromPath(path) {
     var allfs = getAllFS();
     Object.keys(allfs).some(function(fsn) {
     	var fs = allfs[fsn];
-    	if (path.indexOf(fs.root.fullPath) === 0)
+    	if (path.indexOf(fs.winpath) === 0)
     		res = fs;
     	return res;
     });
@@ -168,7 +166,7 @@ function pathFromURL(url) {
 	}
 	if (path.indexOf("file:/")===0) {
 		if (path.indexOf("file://") !== 0) {
-			uri = "file:///" + uri.substr(6);
+			url = "file:///" + url.substr(6);
 		}
 	}
 	
@@ -190,7 +188,7 @@ function getFilesystemFromURL(url) {
 	url=url.replace(msapplhRE,'ms-appdata:///');
 	var res;
 	if (url.indexOf("file:/")===0)
-		res = getFilesystemFromPath(cordovaPathToNative(pathFromURL(url)));
+		res = getFilesystemFromPath(pathFromURL(url));
 	else {
 		var allfs = getAllFS();
 		Object.keys(allfs).every(function(fsn) {

--- a/tests/plugin.xml
+++ b/tests/plugin.xml
@@ -22,7 +22,7 @@
     xmlns:rim="http://www.blackberry.com/ns/widgets"
     xmlns:android="http://schemas.android.com/apk/res/android"
     id="org.apache.cordova.file.tests"
-    version="1.3.2-dev">
+    version="1.3.2">
 
     <name>Cordova File Plugin Tests</name>
     <license>Apache 2.0</license>

--- a/tests/plugin.xml
+++ b/tests/plugin.xml
@@ -22,7 +22,7 @@
     xmlns:rim="http://www.blackberry.com/ns/widgets"
     xmlns:android="http://schemas.android.com/apk/res/android"
     id="org.apache.cordova.file.tests"
-    version="1.3.2">
+    version="1.3.3-dev">
 
     <name>Cordova File Plugin Tests</name>
     <license>Apache 2.0</license>

--- a/tests/tests.js
+++ b/tests/tests.js
@@ -2674,18 +2674,18 @@ exports.defineAutoTests = function () {
                 var fileName = "resolve.file.uri";
                 var dirName = "resolve.dir.uri";
                 // create a new file entry
-				createDirectory(dirName, function () {
-					createFile(dirName+"/../" + fileName, function (entry) {
-						// lookup file system entry
-						window.resolveLocalFileSystemURL(entry.toURL(), function (fileEntry) {
-							expect(fileEntry).toBeDefined();
-							expect(fileEntry.name).toCanonicallyMatch(fileName);
-							// cleanup
-							deleteEntry(fileName);
-							done();
-						}, failed.bind(null, done, 'window.resolveLocalFileSystemURL - Error resolving URI: ' + entry.toURL()));
-					}, failed.bind(null, done, 'createFile - Error creating file: ../' + fileName));
-				}, failed.bind(null, done, 'createDirectory - Error creating directory: ' + dirName));
+                createDirectory(dirName, function () {
+                    createFile(dirName+"/../" + fileName, function (entry) {
+                        // lookup file system entry
+                        window.resolveLocalFileSystemURL(entry.toURL(), function (fileEntry) {
+                            expect(fileEntry).toBeDefined();
+                            expect(fileEntry.name).toCanonicallyMatch(fileName);
+                            // cleanup
+                            deleteEntry(fileName);
+                            done();
+                        }, failed.bind(null, done, 'window.resolveLocalFileSystemURL - Error resolving URI: ' + entry.toURL()));
+                    }, failed.bind(null, done, 'createFile - Error creating file: ../' + fileName));
+                }, failed.bind(null, done, 'createDirectory - Error creating directory: ' + dirName));
             });
             it("file.spec.111 should not traverse above above the root directory", function (done) {
                 var fileName = "traverse.file.uri";
@@ -2696,8 +2696,8 @@ exports.defineAutoTests = function () {
                         create : false
                     }, succeed.bind(null, done, "root.getFile('../"+fileName+ "')- Unexpected success callback, it should not traverse abvoe the root directory"), 
                     function (error) {
-                    	expect(error).toBeDefined();
-                    	done();
+                        expect(error).toBeDefined();
+                        done();
                     });
                 }, failed.bind(null, done, 'createFile - Error creating file: ../' + fileName));
             });
@@ -2729,10 +2729,10 @@ exports.defineAutoTests = function () {
                     create : false
                 }, succeed.bind(null, done, 'root.getFile - Unexpected success callback, it should not locate nonexistent file: ' + fileName), function (error) {
                     expect(error).toBeDefined();
-                    if (cordova.platformId == "windows")
-                    	expect(error).toBeFileError(FileError.SECURITY_ERR);
+                    if (cordova.platformId == "windows8" || cordova.platformId == "windows")
+                        expect(error).toBeFileError(FileError.SECURITY_ERR);
                     else
-						expect(error).toBeFileError(FileError.NOT_FOUND_ERR);
+                        expect(error).toBeFileError(FileError.NOT_FOUND_ERR);
                     done();
                 });
             });
@@ -2742,7 +2742,10 @@ exports.defineAutoTests = function () {
             /* These specs verify that FileEntries have a toNativeURL method
              * which appears to be sane.
              */
-            var pathExpect = cordova.platformId === 'windowsphone' ? "//nativ" : "file://";
+            var pathExpect = cordova.platformId === 'windowsphone' ? "//nativ" : 
+                (cordova.platformId == "windows8" || cordova.platformId == "windows")?
+                "ms-appdata:/":
+                "file://";
             it("file.spec.114 fileEntry should have a toNativeURL method", function (done) {
                 var fileName = "native.file.uri";
                 if (isWindows) {
@@ -2757,8 +2760,7 @@ exports.defineAutoTests = function () {
                     var nativeURL = entry.toNativeURL();
                     var indexOfRoot = isWindows ? rootPath.indexOf(":") : 7;
                     expect(typeof nativeURL).toBe("string");
-                    if (cordova.platformId != "windows")
-						expect(nativeURL.substring(0, 7)).toEqual(pathExpect);
+                    expect(nativeURL.substring(0, pathExpect.length)).toEqual(pathExpect);
                     expect(nativeURL.substring(nativeURL.length - fileName.length)).toEqual(fileName);
                     // cleanup
                     deleteEntry(fileName);
@@ -2777,8 +2779,7 @@ exports.defineAutoTests = function () {
                     var nativeURL = entries[0].toNativeURL();
                     var indexOfRoot = (isWindows) ? nativeURL.indexOf(":") : 7;
                     expect(typeof nativeURL).toBe("string");
-                    if (cordova.platformId != "windows")
-						expect(nativeURL.substring(0, 7)).toEqual(pathExpect);
+                    expect(nativeURL.substring(0, pathExpect.length)).toEqual(pathExpect);
                     expect(nativeURL.substring(nativeURL.length - fileName.length)).toEqual(fileName);
                     // cleanup
                     directory.removeRecursively(null, null);
@@ -2807,8 +2808,7 @@ exports.defineAutoTests = function () {
                         var nativeURL = entry.toNativeURL();
                         var indexOfRoot = (isWindows) ? nativeURL.indexOf(":") : 7;
                         expect(typeof nativeURL).toBe("string");
-                        if (cordova.platformId != "windows")
-                        	expect(nativeURL.substring(0, 7)).toEqual(pathExpect);
+                        expect(nativeURL.substring(0, pathExpect.length)).toEqual(pathExpect);
                         expect(nativeURL.substring(nativeURL.length - fileName.length)).toEqual(fileName);
                         // cleanup
                         deleteEntry(fileName);

--- a/tests/tests.js
+++ b/tests/tests.js
@@ -1,4 +1,4 @@
-﻿/*
+/*
  *
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements. See the NOTICE file

--- a/tests/tests.js
+++ b/tests/tests.js
@@ -1599,6 +1599,24 @@ exports.defineAutoTests = function () {
                     });
                 }, failed.bind(null, done, 'createDirectory - Error creating directory : ' + srcDir));
             });
+            it("file.spec.130 moveTo: directory into similar directory", function (done) {
+                var srcDir = "entry.move.dis.srcDir",
+                dstDir = "entry.move.dis.srcDir-backup",
+                srcPath = joinURL(root.fullPath, srcDir);
+                // create a new directory entry to kick off it
+                createDirectory(srcDir, function (srcDirEntry) {
+                deleteEntry(dstDir, function () {
+                createDirectory(dstDir, function (dstDirEntry) {
+                    // move source directory into itself
+                    srcDirEntry.moveTo(dstDirEntry, 'file', function (newDirEntry) {
+                        expect(newDirEntry).toBeDefined();
+                        deleteEntry(dstDir);
+                        done();
+                    }, failed.bind(null, done, 'directory.moveTo - Error moving a directory into a similarly-named directory: ' + srcDir));
+                }, failed.bind(null, done, 'createDirectory - Error creating directory : ' + dstDir));
+                }, failed.bind(null, done, 'deleteEntry - Error deleting directory : ' + dstDir));
+                }, failed.bind(null, done, 'createDirectory - Error creating directory : ' + srcDir));
+            });
             it("file.spec.72 moveTo: file onto itself", function (done) {
                 var file1 = "entry.move.fos.file1",
                 filePath = joinURL(root.fullPath, file1);

--- a/www/Entry.js
+++ b/www/Entry.js
@@ -109,17 +109,14 @@ Entry.prototype.moveTo = function(parent, newName, successCallback, errorCallbac
     var fail = errorCallback && function(code) {
         errorCallback(new FileError(code));
     };
-    var filesystem = this.filesystem,
-        srcURL = this.toInternalURL(),
+    var srcURL = this.toInternalURL(),
         // entry name
         name = newName || this.name,
         success = function(entry) {
             if (entry) {
                 if (successCallback) {
                     // create appropriate Entry object
-                    var newFSName = entry.filesystemName || (entry.filesystem && entry.filesystem.name);
-                    var fs = newFSName ? new FileSystem(newFSName, { name: "", fullPath: "/" }) : new FileSystem(parent.filesystem.name, { name: "", fullPath: "/" });
-                    var result = (entry.isDirectory) ? new (require('./DirectoryEntry'))(entry.name, entry.fullPath, fs, entry.nativeURL) : new (require('org.apache.cordova.file.FileEntry'))(entry.name, entry.fullPath, fs, entry.nativeURL);
+                    var result = (entry.isDirectory) ? new (require('./DirectoryEntry'))(entry.name, entry.fullPath, parent.filesystem, entry.nativeURL) : new (require('org.apache.cordova.file.FileEntry'))(entry.name, entry.fullPath, parent.filesystem, entry.nativeURL);
                     successCallback(result);
                 }
             }
@@ -150,8 +147,7 @@ Entry.prototype.copyTo = function(parent, newName, successCallback, errorCallbac
     var fail = errorCallback && function(code) {
         errorCallback(new FileError(code));
     };
-    var filesystem = this.filesystem,
-        srcURL = this.toInternalURL(),
+    var srcURL = this.toInternalURL(),
         // entry name
         name = newName || this.name,
         // success callback
@@ -159,9 +155,7 @@ Entry.prototype.copyTo = function(parent, newName, successCallback, errorCallbac
             if (entry) {
                 if (successCallback) {
                     // create appropriate Entry object
-                    var newFSName = entry.filesystemName || (entry.filesystem && entry.filesystem.name);
-                    var fs = newFSName ? new FileSystem(newFSName, { name: "", fullPath: "/" }) : new FileSystem(parent.filesystem.name, { name: "", fullPath: "/" });
-                    var result = (entry.isDirectory) ? new (require('./DirectoryEntry'))(entry.name, entry.fullPath, fs, entry.nativeURL) : new (require('org.apache.cordova.file.FileEntry'))(entry.name, entry.fullPath, fs, entry.nativeURL);
+                    var result = (entry.isDirectory) ? new (require('./DirectoryEntry'))(entry.name, entry.fullPath, parent.filesystem, entry.nativeURL) : new (require('org.apache.cordova.file.FileEntry'))(entry.name, entry.fullPath, parent.filesystem, entry.nativeURL);
                     successCallback(result);
                 }
             }

--- a/www/requestFileSystem.js
+++ b/www/requestFileSystem.js
@@ -46,6 +46,7 @@ var requestFileSystem = function(type, size, successCallback, errorCallback) {
             if (file_system) {
                 if (successCallback) {
                     fileSystems.getFs(file_system.name, function(fs) {
+                        // This should happen only on platforms that haven't implemented requestAllFileSystems (windows)
                         if (!fs) {
                             fs = new FileSystem(file_system.name, file_system.root);
                         }

--- a/www/resolveLocalFileSystemURI.js
+++ b/www/resolveLocalFileSystemURI.js
@@ -53,6 +53,7 @@ module.exports.resolveLocalFileSystemURL = function(uri, successCallback, errorC
                 // create appropriate Entry object
                 var fsName = entry.filesystemName || (entry.filesystem && entry.filesystem.name) || (entry.filesystem == window.PERSISTENT ? 'persistent' : 'temporary');
                 fileSystems.getFs(fsName, function(fs) {
+                    // This should happen only on platforms that haven't implemented requestAllFileSystems (windows)
                     if (!fs) {
                         fs = new FileSystem(fsName, {name:"", fullPath:"/"});
                     }


### PR DESCRIPTION
CB-7883: toURL method called on etnries returned by resolveLocalFileSystemURL and getDirectory produces path instead of URL. 

This rework produce url's in normal form. The code passes all automated tests, although some tests were massaged for windows platform.