### PR TITLE
CB-8092 Adds support for encoded URIs to windows platform

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -316,12 +316,18 @@ xmlns:android="http://schemas.android.com/apk/res/android"
         <js-module src="src/windows/FileProxy.js" name="FileProxy">
             <merges target="" />
         </js-module>
+        <js-module src="www/windows/FileSystem.js" name="windowsFileSystem">
+            <merges target="window.FileSystem" />
+        </js-module>
     </platform>
 
     <!-- windows -->
     <platform name="windows">
         <js-module src="src/windows/FileProxy.js" name="FileProxy">
             <merges target="" />
+        </js-module>
+        <js-module src="www/windows/FileSystem.js" name="windowsFileSystem">
+            <merges target="window.FileSystem" />
         </js-module>
     </platform>
 

--- a/src/windows/FileProxy.js
+++ b/src/windows/FileProxy.js
@@ -31,8 +31,10 @@ var Entry = require('./Entry'),
 
 // Some private helper functions, hidden by the module
 function cordovaPathToNative(path) {
+    // unescape path provided
+    var cleanPath = decodeURI(path);
     // turn / into \\
-    var cleanPath = path.replace(/\//g, '\\');
+    cleanPath = cleanPath.replace(/\//g, '\\');
     // turn  \\ into \
     cleanPath = cleanPath.replace(/\\\\/g, '\\');
     // strip end \\ characters
@@ -313,7 +315,7 @@ module.exports = {
                 } else if (flag.create === true && flag.exclusive === false) {
                     storageFolder.createFolderAsync(path, Windows.Storage.CreationCollisionOption.openIfExists).done(
                         function (storageFolder) {
-                            win(new DirectoryEntry(storageFolder.name, storageFolder.path + "/", getFilesystemFromPath(storageFolder.path + "/")));
+                            win(new DirectoryEntry(storageFolder.name, nativePathToCordova(storageFolder.path), getFilesystemFromPath(storageFolder.path + "/")));
                         }, function () {
                             fail(FileError.INVALID_MODIFICATION_ERR);
                         }

--- a/www/windows/FileSystem.js
+++ b/www/windows/FileSystem.js
@@ -1,0 +1,26 @@
+﻿/*
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *
+*/
+
+module.exports = {
+    __format__: function(fullPath) {
+        return encodeURI(fullPath);
+    }
+};


### PR DESCRIPTION
Fix for [CB-8092](https://issues.apache.org/jira/browse/CB-8092)
* Adds `filesystem._format_()` method for windows which is common place to handle URI encoding.
* Adds encoded URIs support to windows FileProxy methods