### PR TITLE
fix(ios): always use setters to fix memory issues without ARC

### DIFF
--- a/src/ios/CDVAssetLibraryFilesystem.m
+++ b/src/ios/CDVAssetLibraryFilesystem.m
@@ -71,7 +71,7 @@ NSString* const kCDVAssetsLibraryScheme = @"assets-library";
     [dirEntry setObject:fullPath forKey:@"fullPath"];
     [dirEntry setObject:lastPart forKey:@"name"];
     [dirEntry setObject:self.name forKey: @"filesystemName"];
-    
+
     NSURL* nativeURL = [NSURL URLWithString:[NSString stringWithFormat:@"assets-library:/%@",fullPath]];
     if (self.urlTransformer) {
         nativeURL = self.urlTransformer(nativeURL);
@@ -114,7 +114,7 @@ NSString* const kCDVAssetsLibraryScheme = @"assets-library";
 - (id)initWithName:(NSString *)name
 {
     if (self) {
-        _name = name;
+        self.name = name;
     }
     return self;
 }

--- a/src/ios/CDVFile.m
+++ b/src/ios/CDVFile.m
@@ -50,9 +50,9 @@ NSString* const kCDVFilesystemURLPrefix = @"cdvfile";
 -(id) initWithURL:(NSURL *)URL
 {
     if ( self = [super init] ) {
-        _url = URL;
-        _fileSystemName = [self filesystemNameForLocalURI:URL];
-        _fullPath = [self fullPathForLocalURI:URL];
+        self.url = URL;
+        self.fileSystemName = [self filesystemNameForLocalURI:URL];
+        self.fullPath = [self fullPathForLocalURI:URL];
     }
     return self;
 }
@@ -555,10 +555,10 @@ NSString* const kCDVFilesystemURLPrefix = @"cdvfile";
     // arguments
     NSString* localURIstr = [command argumentAtIndex:0];
     CDVPluginResult* result;
-    
+
     localURIstr = [self encodePath:localURIstr]; //encode path before resolving
     CDVFilesystemURL* inputURI = [self fileSystemURLforArg:localURIstr];
-    
+
     if (inputURI == nil || inputURI.fileSystemName == nil) {
         result = [CDVPluginResult resultWithStatus:CDVCommandStatus_ERROR messageAsInt:ENCODING_ERR];
     } else {
@@ -828,7 +828,7 @@ NSString* const kCDVFilesystemURLPrefix = @"cdvfile";
     NSInteger end = [[command argumentAtIndex:3] integerValue];
 
     NSObject<CDVFileSystem> *fs = [self filesystemForURL:localURI];
-    
+
     if (fs == nil) {
         CDVPluginResult* result = [CDVPluginResult resultWithStatus:CDVCommandStatus_IO_EXCEPTION messageAsInt:NOT_FOUND_ERR];
         [self.commandDelegate sendPluginResult:result callbackId:command.callbackId];

--- a/src/ios/CDVLocalFilesystem.m
+++ b/src/ios/CDVLocalFilesystem.m
@@ -29,8 +29,8 @@
 - (id) initWithName:(NSString *)name root:(NSString *)fsRoot
 {
     if (self) {
-        _name = name;
-        _fsRoot = fsRoot;
+        self.name = name;
+        self.fsRoot = fsRoot;
     }
     return self;
 }
@@ -78,12 +78,12 @@
     [dirEntry setObject:fullPath forKey:@"fullPath"];
     [dirEntry setObject:lastPart forKey:@"name"];
     [dirEntry setObject:self.name forKey: @"filesystemName"];
-    
+
     NSURL* nativeURL = [NSURL fileURLWithPath:[self filesystemPathForFullPath:fullPath]];
     if (self.urlTransformer) {
         nativeURL = self.urlTransformer(nativeURL);
     }
-    
+
     dirEntry[@"nativeURL"] = [nativeURL absoluteString];
 
     return dirEntry;
@@ -206,7 +206,7 @@
         NSString *combinedPath = [baseURI.fullPath stringByAppendingPathComponent:requestedPath];
         combinedPath = [self normalizePath:combinedPath];
         CDVFilesystemURL* requestedURL = [self URLforFullPath:combinedPath];
-        
+
         NSFileManager* fileMgr = [[NSFileManager alloc] init];
         BOOL bIsDir;
         BOOL bExists = [fileMgr fileExistsAtPath:[self filesystemPathForURL:requestedURL] isDirectory:&bIsDir];


### PR DESCRIPTION
Encountered memory issues with a non-ARC project (cordova+unity3d). Setter should be used to prevent memory issues, eg:

A synthesized retained setter looks like :

```
- (void)setValue: (id)newValue
{
    if (value != newValue)
    {
        [value release];
        value = newValue;
        [value retain];
    }
} 
```

---

https://issues.apache.org/jira/browse/CB-8669