### PR TITLE
Reading a slice of an asset from photo library on iOS always gets the full file

### DIFF
--- a/src/ios/CDVAssetLibraryFilesystem.m
+++ b/src/ios/CDVAssetLibraryFilesystem.m
@@ -194,8 +194,9 @@ NSString* const kCDVAssetsLibraryScheme = @"assets-library";
         if (asset) {
             // We have the asset!  Get the data and send it off.
             ALAssetRepresentation* assetRepresentation = [asset defaultRepresentation];
-            Byte* buffer = (Byte*)malloc([assetRepresentation size]);
-            NSUInteger bufferSize = [assetRepresentation getBytes:buffer fromOffset:0.0 length:[assetRepresentation size] error:nil];
+            NSUInteger size = (end > start) ? (end - start) : [assetRepresentation size];
+            Byte* buffer = (Byte*)malloc(size);
+            NSUInteger bufferSize = [assetRepresentation getBytes:buffer fromOffset:start length:size error:nil];
             NSData* data = [NSData dataWithBytesNoCopy:buffer length:bufferSize freeWhenDone:YES];
             NSString* MIMEType = (__bridge_transfer NSString*)UTTypeCopyPreferredTagWithClass((__bridge CFStringRef)[assetRepresentation UTI], kUTTagClassMIMEType);
 


### PR DESCRIPTION
When reading a file from photo library, `file.slice()` does not work. Consider this code:

```javascript
resolveLocalFileSystemURL('assets-library://asset/asset.JPG?id=FILE-UUID&ext=JPG', function(fileEntry) {
  fileEntry.file(function(file) {
    var reader = new FileReader();
    reader.onloadend = function(event) {
      console.log(event.target.result.byteLength);
    };
    reader.readAsArrayBuffer(file.slice(100, 200));
  });
});
```

The expected output is 100, but instead it is the full file size.