### PR TITLE
CB-8728 fix write after seek on windows

### DIFF
--- a/src/windows/FileProxy.js
+++ b/src/windows/FileProxy.js
@@ -52,17 +52,49 @@ utils.extend(DirectoryEntry, Entry);
 var getFolderFromPathAsync = Windows.Storage.StorageFolder.getFolderFromPathAsync;
 var getFileFromPathAsync = Windows.Storage.StorageFile.getFileFromPathAsync;
 
-var writeBytesAsync = Windows.Storage.FileIO.writeBytesAsync;
-var writeTextAsync = Windows.Storage.FileIO.writeTextAsync;
-var writeBlobAsync = function writeBlobAsync(storageFile, data) {
+function  writeBytesAsync(storageFile, data, position) {
     return storageFile.openAsync(Windows.Storage.FileAccessMode.readWrite)
     .then(function (output) {
+        output.seek(position);
+        var dataWriter = new Windows.Storage.Streams.DataWriter(output);
+        dataWriter.writeBytes(data);
+        return dataWriter.storeAsync().then(function (size) {
+            output.size = position+size;
+            return dataWriter.flushAsync().then(function() {
+                output.close();
+                return size;
+            });
+        });
+    });
+}
+
+function writeTextAsync(storageFile, data, position) {
+    return storageFile.openAsync(Windows.Storage.FileAccessMode.readWrite)
+    .then(function (output) {
+        output.seek(position);
+        var dataWriter = new Windows.Storage.Streams.DataWriter(output);
+        dataWriter.writeString(data);
+        return dataWriter.storeAsync().then(function (size) {
+            output.size = position+size;
+            return dataWriter.flushAsync().then(function() {
+                output.close();
+                return size;
+            });
+        });
+    });
+}
+
+function writeBlobAsync(storageFile, data, position) {
+    return storageFile.openAsync(Windows.Storage.FileAccessMode.readWrite)
+    .then(function (output) {
+        output.seek(position);
         var dataSize = data.size;
         var input = (data.detachStream || data.msDetachStream).call(data);
 
         // Copy the stream from the blob to the File stream 
         return Windows.Storage.Streams.RandomAccessStream.copyAsync(input, output)
         .then(function () {
+			output.size = position+dataSize;
             return output.flushAsync().then(function () {
                 input.close();
                 output.close();
@@ -71,11 +103,11 @@ var writeBlobAsync = function writeBlobAsync(storageFile, data) {
             });
         });
     });
-};
+}
 
-var writeArrayBufferAsync = function writeArrayBufferAsync(storageFile, data) {
-    return writeBlobAsync(storageFile, new Blob([data]));
-};
+function writeArrayBufferAsync(storageFile, data, position) {
+    return writeBlobAsync(storageFile, new Blob([data]), position);
+}
 
 function cordovaPathToNative(path) {
     // turn / into \\
@@ -996,7 +1028,7 @@ module.exports = {
             function (storageFolder) {
                 storageFolder.createFileAsync(fileName, Windows.Storage.CreationCollisionOption.openIfExists).done(
                     function (storageFile) {
-                        writePromise(storageFile, data).done(
+                        writePromise(storageFile, data, position).done(
                             function (bytesWritten) {
                                 var written = bytesWritten || data.length;
                                 win(written);

--- a/tests/tests.js
+++ b/tests/tests.js
@@ -2376,6 +2376,7 @@ exports.defineAutoTests = function () {
             it("file.spec.96 should be able to write and append to file, createWriter", function (done) {
                 var fileName = "writer.append.createWriter", // file content
                 content = "There is an exception to every rule.", // for checkin file length
+                exception = " Except this one.",
                 length = content.length;
                 // create file, then write and append to it
                 createFile(fileName, function (fileEntry) {
@@ -2386,7 +2387,6 @@ exports.defineAutoTests = function () {
                             expect(writer.length).toBe(length);
                             expect(writer.position).toBe(length);
                             // Append some more data
-                            var exception = " Except this one.";
                             writer.onwriteend = secondVerifier;
                             length += exception.length;
                             writer.seek(writer.length);
@@ -2395,6 +2395,13 @@ exports.defineAutoTests = function () {
                         secondVerifier = function (evt) {
                             expect(writer.length).toBe(length);
                             expect(writer.position).toBe(length);
+                            var reader = new FileReader();
+                            reader.onloadend = thirdVerifier;
+                            reader.onerror = failed.bind(null, done, 'reader.onerror - Error reading file: ' + fileName);
+                            fileEntry.file(function(f){reader.readAsText(f);});
+                        },
+                        thirdVerifier = function (evt) {
+                            expect(evt.target.result).toBe(content+exception);
                             // cleanup
                             deleteFile(fileName, done);
                         };
@@ -2406,7 +2413,8 @@ exports.defineAutoTests = function () {
             });
             it("file.spec.97 should be able to write and append to file, File object", function (done) {
                 var fileName = "writer.append.File", // file content
-                content = "There is an exception to every rule.", // for checking file length
+                content = "There is an exception to every rule.", // for checkin file length
+                exception = " Except this one.",
                 length = content.length;
                 root.getFile(fileName, {
                     create : true
@@ -2417,7 +2425,6 @@ exports.defineAutoTests = function () {
                             expect(writer.length).toBe(length);
                             expect(writer.position).toBe(length);
                             // Append some more data
-                            var exception = " Except this one.";
                             writer.onwriteend = secondVerifier;
                             length += exception.length;
                             writer.seek(writer.length);
@@ -2426,6 +2433,13 @@ exports.defineAutoTests = function () {
                         secondVerifier = function () {
                             expect(writer.length).toBe(length);
                             expect(writer.position).toBe(length);
+                            var reader = new FileReader();
+                            reader.onloadend = thirdVerifier;
+                            reader.onerror = failed.bind(null, done, 'reader.onerror - Error reading file: ' + fileName);
+                            fileEntry.file(function(f){reader.readAsText(f);});
+                        },
+                        thirdVerifier = function (evt) {
+                            expect(evt.target.result).toBe(content+exception);
                             // cleanup
                             deleteFile(fileName, done);
                         };
@@ -2438,6 +2452,7 @@ exports.defineAutoTests = function () {
             it("file.spec.98 should be able to seek to the middle of the file and write more data than file.length", function (done) {
                 var fileName = "writer.seek.write", // file content
                 content = "This is our sentence.", // for checking file length
+                exception = "newer sentence.",
                 length = content.length;
                 // create file, then write and append to it
                 createFile(fileName, function (fileEntry) {
@@ -2447,7 +2462,6 @@ exports.defineAutoTests = function () {
                             expect(writer.length).toBe(length);
                             expect(writer.position).toBe(length);
                             // Append some more data
-                            var exception = "newer sentence.";
                             writer.onwriteend = secondVerifier;
                             length = 12 + exception.length;
                             writer.seek(12);
@@ -2456,6 +2470,13 @@ exports.defineAutoTests = function () {
                         secondVerifier = function (evt) {
                             expect(writer.length).toBe(length);
                             expect(writer.position).toBe(length);
+                            var reader = new FileReader();
+                            reader.onloadend = thirdVerifier;
+                            reader.onerror = failed.bind(null, done, 'reader.onerror - Error reading file: ' + fileName);
+                            fileEntry.file(function(f){reader.readAsText(f);});
+                        },
+                        thirdVerifier = function (evt) {
+                            expect(evt.target.result).toBe(content.substr(0,12)+exception);
                             // cleanup
                             deleteFile(fileName, done);
                         };
@@ -2474,6 +2495,7 @@ exports.defineAutoTests = function () {
 
                 var fileName = "writer.seek.write2", // file content
                 content = "This is our sentence.", // for checking file length
+                exception = "new.",
                 length = content.length;
                 // create file, then write and append to it
                 createFile(fileName, function (fileEntry) {
@@ -2483,7 +2505,6 @@ exports.defineAutoTests = function () {
                             expect(writer.length).toBe(length);
                             expect(writer.position).toBe(length);
                             // Append some more data
-                            var exception = "new.";
                             writer.onwriteend = secondVerifier;
                             length = 8 + exception.length;
                             writer.seek(8);
@@ -2492,6 +2513,13 @@ exports.defineAutoTests = function () {
                         secondVerifier = function (evt) {
                             expect(writer.length).toBe(length);
                             expect(writer.position).toBe(length);
+                            var reader = new FileReader();
+                            reader.onloadend = thirdVerifier;
+                            reader.onerror = failed.bind(null, done, 'reader.onerror - Error reading file: ' + fileName);
+                            fileEntry.file(function(f){reader.readAsText(f);});
+                        },
+                        thirdVerifier = function (evt) {
+                            expect(evt.target.result).toBe(content.substr(0,8)+exception);
                             // cleanup
                             deleteFile(fileName, done);
                         };


### PR DESCRIPTION
write operation of FileWriter overwrites completely contents of existing file after write position was set by seek function. Automated tests for plugin only verify the length of writer object, but do not check the actual data written to file.

Changes included for code and tests.