### PR TITLE
FileProxy.js makeNativeURL() will cause invalid url if last and first characters are / in WIndows

### DIFF
--- a/src/windows/FileProxy.js
+++ b/src/windows/FileProxy.js
@@ -122,7 +122,13 @@ var WinFS = function(name, root) {
         this.winpath += "/";
     }
     this.makeNativeURL = function(path) {
-        return encodeURI(this.root.nativeURL + sanitize(path.replace(':','%3A')));};
+        if (/\/$/.test(this.root.nativeURL)  && /^\//.test(path))
+        {
+            return encodeURI(this.root.nativeURL + sanitize(path.slice(1).replace(':', '%3A')));
+        } else {
+            return encodeURI(this.root.nativeURL + sanitize(path.replace(':', '%3A')));
+        }
+    };
     root.fullPath = '/';
     if (!root.nativeURL)
             root.nativeURL = 'file://'+sanitize(this.winpath + root.fullPath).replace(':','%3A');


### PR DESCRIPTION
This is a fix when accessing the nativeURL of a FileEntry on Windows.  If the file is created and the root.nativeURL contains a '/' at the end, and the path contains a '/' at its beginning.  The native url generated is invalid when you try to access it by calling FileEntry.toURL();