### PR TITLE
fix install on amazon-fireos

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -163,12 +163,13 @@ xmlns:android="http://schemas.android.com/apk/res/android"
         <source-file src="src/android/NoModificationAllowedException.java" target-dir="src/org/apache/cordova/file" />
         <source-file src="src/android/TypeMismatchException.java" target-dir="src/org/apache/cordova/file" />
         <source-file src="src/android/FileUtils.java" target-dir="src/org/apache/cordova/file" />
-        <source-file src="src/android/FileHelper.java" target-dir="src/org/apache/cordova/file" />
         <source-file src="src/android/DirectoryManager.java" target-dir="src/org/apache/cordova/file" />
         <source-file src="src/android/LocalFilesystemURL.java" target-dir="src/org/apache/cordova/file" />
         <source-file src="src/android/Filesystem.java" target-dir="src/org/apache/cordova/file" />
         <source-file src="src/android/LocalFilesystem.java" target-dir="src/org/apache/cordova/file" />
         <source-file src="src/android/ContentFilesystem.java" target-dir="src/org/apache/cordova/file" />
+        <source-file src="src/android/AssetFilesystem.java" target-dir="src/org/apache/cordova/file" />
+
         
         <!-- android specific file apis -->
         <js-module src="www/android/FileSystem.js" name="androidFileSystem">


### PR DESCRIPTION
I'm shooting in the dark, here, so someone knowledgable please check this.

I was previously getting this error:

Failed to install 'cordova-plugin-file':Error: Uh oh!
".../plugins/cordova-plugin-file/src/android/FileHelper.java" not found!

Inspection showed src/android/FileHelper.java doesn't exist, so I removed that line.

I also added the AssetFilesystem.java line for consistency with the android section, but don't know if it's needed.