### PR TITLE
fix(android): remove trailing slash before calling AssetManager#list

### DIFF
--- a/src/android/AssetFilesystem.java
+++ b/src/android/AssetFilesystem.java
@@ -78,6 +78,9 @@ public class AssetFilesystem extends Filesystem {
         if (assetPath.startsWith("/")) {
             assetPath = assetPath.substring(1);
         }
+        if (assetPath.endsWith("/")) {
+            assetPath = assetPath.substring(0, assetPath.length() - 1);
+        }
         lazyInitCaches();
         String[] ret = listCache.get(assetPath);
         if (ret == null) {


### PR DESCRIPTION
We compiled an app without cdvasset.manifest and discovered that an [old issue](https://code.google.com/p/android/issues/detail?id=10664) still exists in Android 4.4.
