### PR TITLE
CB-6703cordova-plugin-file

### DIFF
--- a/src/ios/CDVFile.m
+++ b/src/ios/CDVFile.m
@@ -1062,7 +1062,7 @@ NSString* const kCDVFilesystemURLPrefix = @"cdvfile";
 {
     // no arguments
 
-    NSNumber* pNumAvail = [self checkFreeDiskSpace:self.appDocsPath];
+    NSNumber* pNumAvail = [self checkFreeDiskSpace:self.rootDocsPath];
 
     NSString* strFreeSpace = [NSString stringWithFormat:@"%qu", [pNumAvail unsignedLongLongValue]];
     // NSLog(@"Free space is %@", strFreeSpace );


### PR DESCRIPTION
Fix as discussed in the comments on this Jira issue.

Fix getFreeSpace always returns 0 on iOS

Works on emulator and device now.