### PR TITLE
Prevent passing encoded URIS to native fs apis

### DIFF
--- a/src/windows/FileProxy.js
+++ b/src/windows/FileProxy.js
@@ -129,6 +129,7 @@ function validName(name) {
 }
 
 function sanitize(path) {
+    path = decodeURI(path);
     var slashesRE = new RegExp('/{2,}','g');
     var components = path.replace(slashesRE, '/').split(/\/+/);
     // Remove double dots, use old school array iteration instead of RegExp


### PR DESCRIPTION
The current implementation of FileProxy.js passes encoded URIs to native filesystem apis, causing problems when handling files and directories with international or special characters.

This pulls request prevents passing encoded URIS to native fs apis by decoding them first, like the java implementations does when using the java library's Uri class.

In my tests the best pint to do this results inside sanitize method on FileProxy.js