### PR TITLE
Make Android default persistent file location internal

### DIFF
--- a/README.md
+++ b/README.md
@@ -214,13 +214,13 @@ application's `config.xml` file. To do this, add one of these two lines to
 
     <preference name="AndroidPersistentFileLocation" value="Compatibility" />
 
-Without this line, the File plugin will use `Compatibility` as the default. If
+Without this line, the File plugin will use `Internal` as the default. If
 a preference tag is present, and is not one of these values, the application
 will not start.
 
 If your application has previously been shipped to users, using an older (pre-
-1.0) version of this plugin, and has stored files in the persistent filesystem,
-then you should set the preference to `Compatibility`. Switching the location to
+3.0.0) version of this plugin, and has stored files in the persistent filesystem,
+then you should set the preference to `Compatibility` if your config.xml does not specify a location for the persistent filesystem. Switching the location to
 "Internal" would mean that existing users who upgrade their application may be
 unable to access their previously-stored files, depending on their device.
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cordova-plugin-file",
-  "version": "2.1.1-dev",
+  "version": "3.0.0",
   "description": "Cordova File Plugin",
   "cordova": {
     "id": "cordova-plugin-file",

--- a/plugin.xml
+++ b/plugin.xml
@@ -21,7 +21,7 @@
 <plugin xmlns="http://apache.org/cordova/ns/plugins/1.0"
 xmlns:android="http://schemas.android.com/apk/res/android"
            id="cordova-plugin-file"
-      version="2.1.1-dev">
+      version="3.0.0">
     <name>File</name>
     <description>Cordova File Plugin</description>
     <license>Apache 2.0</license>
@@ -104,6 +104,23 @@ xmlns:android="http://schemas.android.com/apk/res/android"
     <js-module src="www/resolveLocalFileSystemURI.js" name="resolveLocalFileSystemURI">
         <merges target="window" />
     </js-module>
+  
+    <config-file target="config.xml" parent="/*">
+        <preference name="AndroidPersistentFileLocation" value="Internal" />
+    </config-file>
+  
+    <info>
+The Android Persistent storage location now defaults to "Internal". Please check this plugins README to see if you application needs any changes in its config.xml.
+      
+If this is a new application no changes are required.
+      
+If this is an update to an existing application that did not specify an "AndroidPersistentFileLocation" you may need to add:
+      
+      "&lt;preference name="AndroidPersistentFileLocation" value="Compatibility" /&gt;"
+      
+to config.xml in order for the application to find previously stored files.
+      
+    </info>
 
     <!-- android -->
     <platform name="android">

--- a/src/android/FileUtils.java
+++ b/src/android/FileUtils.java
@@ -153,7 +153,7 @@ public class FileUtils extends CordovaPlugin {
     	Activity activity = cordova.getActivity();
     	String packageName = activity.getPackageName();
 
-        String location = preferences.getString("androidpersistentfilelocation", "compatibility");
+        String location = preferences.getString("androidpersistentfilelocation", "internal");
 
     	tempRoot = activity.getCacheDir().getAbsolutePath();
     	if ("internal".equalsIgnoreCase(location)) {


### PR DESCRIPTION
**TL;DR Summary**

We should switch the default for the Cordova Android File System to be on internal storage, not the SD Card (or emulated SD card).

**Long Version**

Currently in Cordova Android when you use this code "window.requestFileSystem(PERSISTENT, 0, win, fail);" the root file system path that is returned is "/storage/emulated/0" i.e. "/sdcard".

Why you may ask? Because back in 2010 or so Bryce Curtis and I argued that we should use the external storage location because internal storage was not very large on Android 2.x and we didn't want to have developers filling up the devices limited internal storage. Joe Bowser argued against it because of issues with the SD Card on Android but was eventually out voted.

Now, I'm prepared to admit that Bryce was wrong (see what I did there?). I feel that the default behaviour for "window.requestFileSystem(PERSISTENT, 0, win, fail);" should be to resolve to a location on internal storage that meets the following requirements:

a) private to the application

b) removed when the application is uninstalled

c) lines up with what we have on iOS and WP

In fact you can get this behaviour right now but setting the following preference in config.xml:

&lt;preference name="AndroidPersistentFileLocation" value="Internal" /&gt;

This gets you a root file path of "/data/data/{android package}/files/files/". The double "files" is an issue but we can probably ignore it for now.

If a user wants the old behaviour they only need to make the preference:

&lt;preference name="AndroidPersistentFileLocation" value="Compatibility" /&gt;

and the original behaviour will be retained.

What I'm advocating for is to make internal storage the default behaviour for Cordova Android.