### PR TITLE
Fix crash and add new feature

### DIFF
--- a/src/android/ContentFilesystem.java
+++ b/src/android/ContentFilesystem.java
@@ -184,7 +184,7 @@ public class ContentFilesystem extends Filesystem {
         return null;
 	}
 	
-	protected Long lastModifiedDateForCursor(Cursor cursor) {
+	protected long lastModifiedDateForCursor(Cursor cursor) {
         final String[] LOCAL_FILE_PROJECTION = { MediaStore.MediaColumns.DATE_MODIFIED };
         int columnIndex = cursor.getColumnIndex(LOCAL_FILE_PROJECTION[0]);
         if (columnIndex != -1) {
@@ -193,7 +193,7 @@ public class ContentFilesystem extends Filesystem {
             	return Long.parseLong(dateStr);
             }
         }
-        return null;
+        return 0;
 	}
 
     @Override

--- a/www/Entry.js
+++ b/www/Entry.js
@@ -67,7 +67,8 @@ Entry.prototype.getMetadata = function(successCallback, errorCallback) {
     var success = successCallback && function(entryMetadata) {
         var metadata = new Metadata({
             size: entryMetadata.size,
-            modificationTime: entryMetadata.lastModifiedDate
+            modificationTime: entryMetadata.lastModifiedDate,
+            type: entryMetadata.type
         });
         successCallback(metadata);
     };

--- a/www/Metadata.js
+++ b/www/Metadata.js
@@ -28,9 +28,11 @@ var Metadata = function(metadata) {
     if (typeof metadata == "object") {
         this.modificationTime = new Date(metadata.modificationTime);
         this.size = metadata.size || 0;
+        this.type = metadata.type || '';
     } else if (typeof metadata == "undefined") {
         this.modificationTime = null;
         this.size = 0;
+        this.type = null;
     } else {
         /* Backwards compatiblity with platforms that only return a timestamp */
         this.modificationTime = new Date(metadata);


### PR DESCRIPTION
1- Fix crash when modified date is null (NullPointerException)
2- Added mime-type to Metadata (in Android when Content filesystem is used is the only way to know which file type is being handled.