### PR TITLE
CB-9763: added handling for encoding exception in readAsText on Windows

### DIFF
--- a/src/windows/FileProxy.js
+++ b/src/windows/FileProxy.js
@@ -561,7 +561,12 @@ module.exports = {
 
                 return stream.readAsync(buffer, readSize, Windows.Storage.Streams.InputStreamOptions.none);
             }).done(function(buffer) {
-                win(Windows.Security.Cryptography.CryptographicBuffer.convertBinaryToString(encoding, buffer));
+            	try {
+            		win(Windows.Security.Cryptography.CryptographicBuffer.convertBinaryToString(encoding, buffer));
+                }
+                catch (e) {
+                	fail(FileError.ENCODING_ERR);
+                }
             },function() {
                 fail(FileError.NOT_FOUND_ERR);
             });


### PR DESCRIPTION
readAsText on windows uses Windows.Security.Cryptography.CryptographicBuffer.convertBinaryToString to convert buffer to requested exception. When such conversion can not be made, it throws exception, that is currently not handled. The function shall fail with FileError.ENCODING_ERR instead.