### PR TITLE
Add handling for SecurityException

### DIFF
--- a/src/android/FileUtils.java
+++ b/src/android/FileUtils.java
@@ -580,6 +580,8 @@ public class FileUtils extends CordovaPlugin {
                         callbackContext.error(FileUtils.TYPE_MISMATCH_ERR);
                     } else if(e instanceof JSONException ) {
                         callbackContext.sendPluginResult(new PluginResult(PluginResult.Status.JSON_EXCEPTION));
+                    } else if (e instanceof SecurityException) {
+                        callbackContext.error(FileUtils.SECURITY_ERR);
                     } else {
                         e.printStackTrace();
                     	callbackContext.error(FileUtils.UNKNOWN_ERR);


### PR DESCRIPTION
Instead of returning UNKNOWN_ERR, return SECURITY_ERR when a SecurityException is caught.