### PR TITLE
CB-9887 cordova.file.* paths for windows platform

### DIFF
--- a/README.md
+++ b/README.md
@@ -212,13 +212,13 @@ properties are `null`.
 
 ### Windows File System Layout
 
-| Device Path                                     | `cordova.file.*`            | r/w? | persistent? | OS clears | private |
-|:------------------------------------------------|:----------------------------|:----:|:-----------:|:---------:|:-------:|
-| `ms-appdata:///`                                | applicationDirectory        | r    |     N/A     |     N/A   |   Yes   |
-| &nbsp;&nbsp;`local/`                            | dataDirectory               | r/w  |     Yes     |     No    |   Yes   |
-| &nbsp;&nbsp;'temp/'                             | cacheDirectory              | r/w  |     Yes     |     Yes\* |   Yes   |
-| &nbsp;&nbsp;`temp/`                             | tempDirectory               | r/w  |     Yes     |     Yes\* |   Yes   |
-| &nbsp;&nbsp;`roaming/`                          | syncedDataDirectory         | r/w  |     Yes     |     No    |   Yes   |
+| Device Path                                           | `cordova.file.*`            | r/w? | persistent? | OS clears | private |
+|:------------------------------------------------------|:----------------------------|:----:|:-----------:|:---------:|:-------:|
+| `ms-appdata:///`                                      | applicationDirectory        | r    |     N/A     |     N/A   |   Yes   |
+| &nbsp;&nbsp;&nbsp;`local/`                            | dataDirectory               | r/w  |     Yes     |     No    |   Yes   |
+| &nbsp;&nbsp;&nbsp;`temp/`                             | cacheDirectory              | r/w  |     Yes     |     Yes\* |   Yes   |
+| &nbsp;&nbsp;&nbsp;`temp/`                             | tempDirectory               | r/w  |     Yes     |     Yes\* |   Yes   |
+| &nbsp;&nbsp;&nbsp;`roaming/`                          | syncedDataDirectory         | r/w  |     Yes     |     No    |   Yes   |
 
 \* The OS may periodically clear this directory
 

--- a/README.md
+++ b/README.md
@@ -216,8 +216,8 @@ properties are `null`.
 |:------------------------------------------------------|:----------------------------|:----:|:-----------:|:---------:|:-------:|
 | `ms-appdata:///`                                      | applicationDirectory        | r    |     N/A     |     N/A   |   Yes   |
 | &nbsp;&nbsp;&nbsp;`local/`                            | dataDirectory               | r/w  |     Yes     |     No    |   Yes   |
-| &nbsp;&nbsp;&nbsp;`temp/`                             | cacheDirectory              | r/w  |     Yes     |     Yes\* |   Yes   |
-| &nbsp;&nbsp;&nbsp;`temp/`                             | tempDirectory               | r/w  |     Yes     |     Yes\* |   Yes   |
+| &nbsp;&nbsp;&nbsp;`temp/`                             | cacheDirectory              | r/w  |     No      |     Yes\* |   Yes   |
+| &nbsp;&nbsp;&nbsp;`temp/`                             | tempDirectory               | r/w  |     No      |     Yes\* |   Yes   |
 | &nbsp;&nbsp;&nbsp;`roaming/`                          | syncedDataDirectory         | r/w  |     Yes     |     No    |   Yes   |
 
 \* The OS may periodically clear this directory

--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ Each URL is in the form _file:///path/to/spot/_, and can be converted to a
 `DirectoryEntry` using `window.resolveLocalFileSystemURL()`.
 
 * `cordova.file.applicationDirectory` - Read-only directory where the application
-  is installed. (_iOS_, _Android_, _BlackBerry 10_, _OSX_)
+  is installed. (_iOS_, _Android_, _BlackBerry 10_, _OSX_, _windows_)
 
 * `cordova.file.applicationStorageDirectory` - Root directory of the application's
   sandbox; on iOS this location is read-only (but specific subdirectories [like
@@ -86,12 +86,12 @@ Each URL is in the form _file:///path/to/spot/_, and can be converted to a
 * `cordova.file.dataDirectory` - Persistent and private data storage within the
   application's sandbox using internal memory (on Android, if you need to use
   external memory, use `.externalDataDirectory`). On iOS, this directory is not
-  synced with iCloud (use `.syncedDataDirectory`). (_iOS_, _Android_, _BlackBerry 10_)
+  synced with iCloud (use `.syncedDataDirectory`). (_iOS_, _Android_, _BlackBerry 10_, _windows_)
 
 * `cordova.file.cacheDirectory` -  Directory for cached data files or any files
   that your app can re-create easily. The OS may delete these files when the device
   runs low on storage, nevertheless, apps should not rely on the OS to delete files
-  in here. (_iOS_, _Android_, _BlackBerry 10_, _OSX_)
+  in here. (_iOS_, _Android_, _BlackBerry 10_, _OSX_, _windows_)
 
 * `cordova.file.externalApplicationStorageDirectory` - Application space on
   external storage. (_Android_)
@@ -106,10 +106,10 @@ Each URL is in the form _file:///path/to/spot/_, and can be converted to a
 
 * `cordova.file.tempDirectory` - Temp directory that the OS can clear at will. Do not
   rely on the OS to clear this directory; your app should always remove files as
-  applicable. (_iOS_, _OSX_)
+  applicable. (_iOS_, _OSX_, _windows_)
 
 * `cordova.file.syncedDataDirectory` - Holds app-specific files that should be synced
-  (e.g. to iCloud). (_iOS_)
+  (e.g. to iCloud). (_iOS_, _windows_)
 
 * `cordova.file.documentsDirectory` - Files private to the app, but that are meaningful
   to other application (e.g. Office files). Note that for _OSX_ this is the user's `~/Documents` directory. (_iOS_, _OSX_)
@@ -193,7 +193,7 @@ properties are `null`.
 | Device Path                                      | `cordova.file.*`            | `iosExtraFileSystems` | r/w? |  OS clears | private |
 |:-------------------------------------------------|:----------------------------|:----------------------|:----:|:---------:|:-------:|
 | `/Applications/<appname>.app/`                   | -                           | bundle                | r    |     N/A   |   Yes   |
-| &nbsp;&nbsp;&nbsp;&nbsp;`Content/Resources/`    | applicationDirectory        | -                     | r    |     N/A   |   Yes   |
+| &nbsp;&nbsp;&nbsp;&nbsp;`Content/Resources/`     | applicationDirectory        | -                     | r    |     N/A   |   Yes   |
 | `~/Library/Application Support/<bundle-id>/`     | applicationStorageDirectory | -                     | r/w  |     No    |   Yes   |
 | &nbsp;&nbsp;&nbsp;&nbsp;`files/`                 | dataDirectory               | -                     | r/w  |     No    |   Yes   |
 | `~/Documents/`                                   | documentsDirectory          | documents             | r/w  |     No    |    No   |
@@ -209,6 +209,18 @@ properties are `null`.
      appropriate for your application.
 
 \*\* Allows access to the entire file system. This is only available for non sandboxed apps.
+
+### Windows File System Layout
+
+| Device Path                                     | `cordova.file.*`            | r/w? | persistent? | OS clears | private |
+|:------------------------------------------------|:----------------------------|:----:|:-----------:|:---------:|:-------:|
+| `ms-appdata:///`                                | applicationDirectory        | r    |     N/A     |     N/A   |   Yes   |
+| &nbsp;&nbsp;`local/`                            | dataDirectory               | r/w  |     Yes     |     No    |   Yes   |
+| &nbsp;&nbsp;'temp/'                             | cacheDirectory              | r/w  |     Yes     |     Yes\* |   Yes   |
+| &nbsp;&nbsp;`temp/`                             | tempDirectory               | r/w  |     Yes     |     Yes\* |   Yes   |
+| &nbsp;&nbsp;`roaming/`                          | syncedDataDirectory         | r/w  |     Yes     |     No    |   Yes   |
+
+\* The OS may periodically clear this directory
 
 
 ## Android Quirks

--- a/README.md
+++ b/README.md
@@ -79,9 +79,9 @@ Each URL is in the form _file:///path/to/spot/_, and can be converted to a
   is installed. (_iOS_, _Android_, _BlackBerry 10_, _OSX_, _windows_)
 
 * `cordova.file.applicationStorageDirectory` - Root directory of the application's
-  sandbox; on iOS this location is read-only (but specific subdirectories [like
-  `/Documents`] are read-write). All data contained within is private to the app. (
-  _iOS_, _Android_, _BlackBerry 10_, _OSX_)
+  sandbox; on iOS & windows this location is read-only (but specific subdirectories [like
+  `/Documents` on iOS or `/localState` on windows] are read-write). All data contained within
+  is private to the app. (_iOS_, _Android_, _BlackBerry 10_, _OSX_)
 
 * `cordova.file.dataDirectory` - Persistent and private data storage within the
   application's sandbox using internal memory (on Android, if you need to use

--- a/plugin.xml
+++ b/plugin.xml
@@ -365,12 +365,22 @@ to config.xml in order for the application to find previously stored files.
         <js-module src="src/windows/FileProxy.js" name="FileProxy">
             <merges target="" />
         </js-module>
+
+        <js-module src="www/fileSystemPaths.js" name="fileSystemPaths">
+            <merges target="cordova" />
+            <runs/>
+        </js-module>
     </platform>
 
     <!-- windows -->
     <platform name="windows">
         <js-module src="src/windows/FileProxy.js" name="FileProxy">
             <merges target="" />
+        </js-module>
+
+        <js-module src="www/fileSystemPaths.js" name="fileSystemPaths">
+            <merges target="cordova" />
+            <runs/>
         </js-module>
     </platform>
 

--- a/src/windows/FileProxy.js
+++ b/src/windows/FileProxy.js
@@ -497,7 +497,7 @@ module.exports = {
     },
     requestAllPaths: function(success){
         success(windowsPaths);
-    }
+    },
     getFileMetadata: function (success, fail, args) {
         module.exports.getMetadata(success, fail, args);
     },

--- a/src/windows/FileProxy.js
+++ b/src/windows/FileProxy.js
@@ -173,8 +173,8 @@ var windowsPaths = {
     cacheDirectory: "ms-appdata:///temp/",
     tempDirectory: "ms-appdata:///temp/",
     syncedDataDirectory: "ms-appdata:///roaming/",
-    applicationDirectory: "ms-appdata:///",
-    applicationStorageDirectory: "ms-appdata:///"
+    applicationDirectory: "ms-appx:///",
+    applicationStorageDirectory: "ms-appx:///"
 };
 
 var AllFileSystems; 

--- a/src/windows/FileProxy.js
+++ b/src/windows/FileProxy.js
@@ -173,7 +173,8 @@ var windowsPaths = {
     cacheDirectory: "ms-appdata:///temp/",
     tempDirectory: "ms-appdata:///temp/",
     syncedDataDirectory: "ms-appdata:///roaming/",
-    applicationDirectory: "ms-appdata:///"
+    applicationDirectory: "ms-appdata:///",
+    applicationStorageDirectory: "ms-appdata:///"
 };
 
 var AllFileSystems; 

--- a/src/windows/FileProxy.js
+++ b/src/windows/FileProxy.js
@@ -168,6 +168,14 @@ WinFS.prototype.__format__ = function(fullPath) {
     return 'cdvfile://localhost' + path;
 };
 
+var windowsPaths = {
+    dataDirectory: "ms-appdata:///local/",
+    cacheDirectory: "ms-appdata:///temp/",
+    tempDirectory: "ms-appdata:///temp/",
+    syncedDataDirectory: "ms-appdata:///roaming/",
+    applicationDirectory: "ms-appdata:///"
+};
+
 var AllFileSystems; 
 
 function getAllFS() {
@@ -487,6 +495,9 @@ module.exports = {
     requestAllFileSystems: function() {
         return getAllFS();
     },
+    requestAllPaths: function(success){
+        success(windowsPaths);
+    }
     getFileMetadata: function (success, fail, args) {
         module.exports.getMetadata(success, fail, args);
     },


### PR DESCRIPTION
Update the plugin to define cordova.file.* paths for windows platform as appropriate.

Documentation updated to show where to store things.

Have tested this in my own app and the paths are detected as file plugin works as expected now.

Means you can use cordova.file.dataDirectory in your app and then run that app on ios, android, windows with consistent behaviour without requiring platform specific code.