### PR TITLE
Fix CB-9752: FileEntry.getDirectory fails with assets filesystem

### DIFF
--- a/src/android/AssetFilesystem.java
+++ b/src/android/AssetFilesystem.java
@@ -78,6 +78,9 @@ public class AssetFilesystem extends Filesystem {
         if (assetPath.startsWith("/")) {
             assetPath = assetPath.substring(1);
         }
+        if (assetPath.endsWith("/")) {
+            assetPath = assetPath.substring(0, assetPath.length() - 1);
+        }
         lazyInitCaches();
         String[] ret = listCache.get(assetPath);
         if (ret == null) {

--- a/tests/tests.js
+++ b/tests/tests.js
@@ -30,7 +30,7 @@ exports.defineAutoTests = function () {
     var isIndexedDBShim = isBrowser && !isChrome;   // Firefox and IE for example
 
     var isWindows = (cordova.platformId === "windows" || cordova.platformId === "windows8");
-    
+
     var MEDIUM_TIMEOUT = 15000;
 
     describe('File API', function () {
@@ -3500,6 +3500,33 @@ exports.defineAutoTests = function () {
                             expect(entries.length).not.toBe(0);
                             done();
                         }, failed.bind(null, done, 'reader.readEntries - Error during reading of entries from assets directory'));
+                    }, failed.bind(null, done, 'resolveLocalFileSystemURL failed for assets'));
+                }, MEDIUM_TIMEOUT);
+                it("file.spec.145 asset subdirectories should be obtainable", function(done) {
+                    resolveLocalFileSystemURL('file:///android_asset/www/fixtures', function(entry) {
+                        entry.getDirectory('asset-test', { create: false }, function (subDir) {
+                            expect(subDir).toBeDefined();
+                            expect(subDir.isFile).toBe(false);
+                            expect(subDir.isDirectory).toBe(true);
+                            expect(subDir.name).toCanonicallyMatch('asset-test');
+                            done();
+                        }, failed.bind(null, done, 'entry.getDirectory - Error getting asset subdirectory'));
+                    }, failed.bind(null, done, 'resolveLocalFileSystemURL failed for assets'));
+                }, MEDIUM_TIMEOUT);
+                it("file.spec.146 asset files should be readable", function(done) {
+                    resolveLocalFileSystemURL('file:///android_asset/www/fixtures/asset-test/asset-test.txt', function(entry) {
+                        expect(entry.isFile).toBe(true);
+                        entry.file(function (file) {
+                            expect(file).toBeDefined();
+                            var reader = new FileReader();
+                            reader.onerror = failed.bind(null, done, 'reader.readAsText - Error reading asset text file');
+                            reader.onloadend = function () {
+                                expect(this.result).toBeDefined();
+                                expect(this.result.length).not.toBe(0);
+                                done();
+                            };
+                            reader.readAsText(file);
+                        }, failed.bind(null, done, 'entry.file - Error reading asset file'));
                     }, failed.bind(null, done, 'resolveLocalFileSystemURL failed for assets'));
                 }, MEDIUM_TIMEOUT);
                 it("file.spec.143 copyTo: asset -> temporary", function(done) {


### PR DESCRIPTION
Calls to FileEntry.getDirectory() on an asset entry would internally call
the AssetFileSystem.listAssets() method using an asset path with a
trailing slash, regardless of whether a trailing slash was included by
the user. But neither the asset list cache (from cdvasset.manifest) nor
Android's AssetManager.list() API support matching a path with a trailing
slash. That resulted in a TypeMismatchException thrown from
AssetFileSystem.getFileForLocalURL(), because the asset path was found
but not matched as a directory as expected by the caller.

This fix removes the trailing slash from the asset path before matching
against the asset list cache or calling Android's AssetManager.list() API.
A new unit test for getting asset directories fails without and passes
with the fix.

While I'm here, I'm also adding a unit test for reading asset file
contents. There are a couple old bug reports about that (CB-7273,
CB-8350). The bugs don't repro anymore, but I'm adding the test anyway
since there wasn't good test coverage before.