### PR TITLE
Fix default persistent file location

### DIFF
--- a/src/android/FileUtils.java
+++ b/src/android/FileUtils.java
@@ -175,7 +175,7 @@ public class FileUtils extends CordovaPlugin {
     	Activity activity = cordova.getActivity();
     	String packageName = activity.getPackageName();
 
-        String location = preferences.getString("androidpersistentfilelocation", "compatibility");
+        String location = preferences.getString("androidpersistentfilelocation", "internal");
 
     	tempRoot = activity.getCacheDir().getAbsolutePath();
     	if ("internal".equalsIgnoreCase(location)) {


### PR DESCRIPTION
The default Android persistent file location should be "internal", as documented in the file plugin's README.md. The value was unintentionally changed in a recent commit.