### PR TITLE
CB-8497 Fix handling of file paths with # character

### DIFF
--- a/src/windows/FileProxy.js
+++ b/src/windows/FileProxy.js
@@ -154,7 +154,7 @@ var WinFS = function(name, root) {
         this.winpath += "/";
     }
     this.makeNativeURL = function(path) {
-        return encodeURI(this.root.nativeURL + sanitize(path.replace(':','%3A')));};
+        return FileSystem.encodeURIPath(this.root.nativeURL + sanitize(path.replace(':','%3A')));};
     root.fullPath = '/';
     if (!root.nativeURL)
             root.nativeURL = 'file://'+sanitize(this.winpath + root.fullPath).replace(':','%3A');
@@ -164,7 +164,7 @@ var WinFS = function(name, root) {
 utils.extend(WinFS, FileSystem);
 
 WinFS.prototype.__format__ = function(fullPath) {
-    var path = sanitize('/'+this.name+(fullPath[0]==='/'?'':'/')+encodeURI(fullPath));
+    var path = sanitize('/'+this.name+(fullPath[0]==='/'?'':'/')+FileSystem.encodeURIPath(fullPath));
     return 'cdvfile://localhost' + path;
 };
 
@@ -234,7 +234,7 @@ function getFilesystemFromPath(path) {
 var msapplhRE = new RegExp('^ms-appdata://localhost/');
 function pathFromURL(url) {
     url=url.replace(msapplhRE,'ms-appdata:///');
-    var path = decodeURI(url);
+    var path = decodeURIComponent(url);
     // support for file name with parameters
     if (/\?/g.test(path)) {
         path = String(path).split("?")[0];
@@ -256,7 +256,7 @@ function pathFromURL(url) {
         }
     });
     
-    return path.replace('%3A',':').replace(driveRE,'$1');
+    return path.replace(driveRE,'$1');
 }
 
 function getFilesystemFromURL(url) {

--- a/tests/tests.js
+++ b/tests/tests.js
@@ -1156,6 +1156,21 @@ exports.defineAutoTests = function () {
                     }, failed.bind(null, done, 'entry.remove - Error removing entry : ' + fileName));
                 }, failed.bind(null, done, 'createFile - Error creating file : ' + fileName));
             });
+            it("file.spec.53.1 Entry.remove on filename with #s", function (done) {
+                var fileName = "entry.#rm#.file";
+                // create a new file entry
+                createFile(fileName, function (entry) {
+                    expect(entry).toBeDefined();
+                    entry.remove(function () {
+                        root.getFile(fileName, null, succeed.bind(null, done, 'root.getFile - Unexpected success callback, it should not get deleted file : ' + fileName), function (error) {
+                            expect(error).toBeDefined();
+                            expect(error).toBeFileError(FileError.NOT_FOUND_ERR);
+                            // cleanup
+                            deleteEntry(fileName, done);
+                        });
+                    }, failed.bind(null, done, 'entry.remove - Error removing entry : ' + fileName));
+                }, failed.bind(null, done, 'createFile - Error creating file : ' + fileName));
+            });
             it("file.spec.54 remove on empty directory", function (done) {
                 var dirName = "entry.rm.dir";
                 // create a new directory entry

--- a/www/FileSystem.js
+++ b/www/FileSystem.js
@@ -45,4 +45,11 @@ FileSystem.prototype.toJSON = function() {
     return "<FileSystem: " + this.name + ">";
 };
 
+// Use instead of encodeURI() when encoding just the path part of a URI rather than an entire URI.
+FileSystem.encodeURIPath = function(path) {
+    // Because # is a valid filename character, it must be encoded to prevent part of the
+    // path from being parsed as a URI fragment.
+    return encodeURI(path).replace(/#/g, '%23');
+}
+
 module.exports = FileSystem;

--- a/www/android/FileSystem.js
+++ b/www/android/FileSystem.js
@@ -32,7 +32,7 @@ module.exports = {
             // doesn't match the string for which permission was originally granted.
             path = nativeUrl.substring(contentUrlMatch[0].length - 1);
         } else {
-            path = encodeURI(fullPath);
+            path = FileSystem.encodeURIPath(fullPath);
             if (!/^\//.test(path)) {
                 path = '/' + path;
             }

--- a/www/blackberry10/FileSystem.js
+++ b/www/blackberry10/FileSystem.js
@@ -31,16 +31,16 @@ module.exports = {
     __format__: function(fullPath) {
         switch (this.name) {
             case 'temporary':
-                path = info.temporaryPath + fullPath;
+                path = info.temporaryPath + FileSystem.encodeURIPath(fullPath);
                 break;
             case 'persistent':
-                path = info.persistentPath + fullPath;
+                path = info.persistentPath + FileSystem.encodeURIPath(fullPath);
                 break;
             case 'root':
-                path = 'file://' + fullPath;
+                path = 'file://' + FileSystem.encodeURIPath(fullPath);
                 break;
         }
-        return window.encodeURI(path);
+        return path;
     }
 };
 

--- a/www/blackberry10/createEntryFromNative.js
+++ b/www/blackberry10/createEntryFromNative.js
@@ -45,11 +45,11 @@ module.exports = function (native) {
         temporaryPath = info.temporaryPath.substring(7);
     //fix bb10 webkit incorrect nativeURL
     if (native.filesystem.name === 'root') {
-        entry.nativeURL = 'file:///' + native.fullPath;
+        entry.nativeURL = 'file:///' + FileSystem.encodeURIPath(native.fullPath);
     } else if (entry.nativeURL.indexOf('filesystem:local:///persistent/') === 0) {
-        entry.nativeURL = info.persistentPath + native.fullPath;
+        entry.nativeURL = info.persistentPath + FileSystem.encodeURIPath(native.fullPath);
     } else if (entry.nativeURL.indexOf('filesystem:local:///temporary') === 0) {
-        entry.nativeURL = info.temporaryPath + native.fullPath;
+        entry.nativeURL = info.temporaryPath + FileSystem.encodeURIPath(native.fullPath);
     }
     //translate file system name from bb10 webkit
     if (entry.filesystemName === 'local__0:Persistent' || entry.fullPath.indexOf(persistentPath) !== -1) {
@@ -71,7 +71,5 @@ module.exports = function (native) {
     if (entry.isDirectory && entry.nativeURL.substring(entry.nativeURL.length - 1) !== '/') {
         entry.nativeURL += '/';
     }
-    //encode URL
-    entry.nativeURL = window.encodeURI(entry.nativeURL);
     return entry;
 };

--- a/www/browser/FileSystem.js
+++ b/www/browser/FileSystem.js
@@ -25,7 +25,7 @@ FILESYSTEM_PREFIX = "file:///";
 
 module.exports = {
     __format__: function(fullPath) {
-        return (FILESYSTEM_PREFIX + this.name + (fullPath[0] === '/' ? '' : '/') + encodeURI(fullPath));
+        return (FILESYSTEM_PREFIX + this.name + (fullPath[0] === '/' ? '' : '/') + FileSystem.encodeURIPath(fullPath));
     }
 };
 

--- a/www/firefoxos/FileSystem.js
+++ b/www/firefoxos/FileSystem.js
@@ -23,7 +23,7 @@ FILESYSTEM_PREFIX = "file:///";
 
 module.exports = {
     __format__: function(fullPath) {
-        return (FILESYSTEM_PREFIX + this.name + (fullPath[0] === '/' ? '' : '/') + encodeURI(fullPath));
+        return (FILESYSTEM_PREFIX + this.name + (fullPath[0] === '/' ? '' : '/') + FileSystem.encodeURIPath(fullPath));
     }
 };
 

--- a/www/ios/FileSystem.js
+++ b/www/ios/FileSystem.js
@@ -23,7 +23,7 @@ FILESYSTEM_PROTOCOL = "cdvfile";
 
 module.exports = {
     __format__: function(fullPath) {
-        var path = ('/'+this.name+(fullPath[0]==='/'?'':'/')+encodeURI(fullPath)).replace('//','/');
+        var path = ('/'+this.name+(fullPath[0]==='/'?'':'/')+FileSystem.encodeURIPath(fullPath)).replace('//','/');
         return FILESYSTEM_PROTOCOL + '://localhost' + path;
     }
 };

--- a/www/osx/FileSystem.js
+++ b/www/osx/FileSystem.js
@@ -23,7 +23,7 @@ FILESYSTEM_PROTOCOL = "cdvfile";
 
 module.exports = {
     __format__: function(fullPath) {
-        var path = ('/'+this.name+(fullPath[0]==='/'?'':'/')+encodeURI(fullPath)).replace('//','/');
+        var path = ('/'+this.name+(fullPath[0]==='/'?'':'/')+FileSystem.encodeURIPath(fullPath)).replace('//','/');
         return FILESYSTEM_PROTOCOL + '://localhost' + path;
     }
 };

--- a/www/ubuntu/FileSystem.js
+++ b/www/ubuntu/FileSystem.js
@@ -26,7 +26,7 @@ module.exports = {
         if (this.name === 'content') {
             return 'content:/' + fullPath;
         }
-        var path = ('/' + this.name + (fullPath[0] === '/' ? '' : '/') + encodeURI(fullPath)).replace('//','/');
+        var path = ('/' + this.name + (fullPath[0] === '/' ? '' : '/') + FileSystem.encodeURIPath(fullPath)).replace('//','/');
 
         return FILESYSTEM_PROTOCOL + '://localhost' + path;
     }


### PR DESCRIPTION
Because # is a valid filename character, it must be encoded whenever it
is in a path that is part of a URI, to prevent part of the path from
being parsed as a URI fragment.