### PR TITLE
CB-10023 Fix "proxy not found error" on Chrome.

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -398,6 +398,10 @@ to config.xml in order for the application to find previously stored files.
     </platform>
 
     <platform name="browser">
+        <js-module src="www/browser/isChrome.js" name="isChrome">
+            <runs />
+        </js-module>
+
         <!-- File for Chrome -->
         <js-module src="www/browser/Preparing.js" name="Preparing">
             <runs />

--- a/src/browser/FileProxy.js
+++ b/src/browser/FileProxy.js
@@ -25,14 +25,9 @@
 
 /* Heavily based on https://github.com/ebidel/idb.filesystem.js */
 
-// window.webkitRequestFileSystem and window.webkitResolveLocalFileSystemURL
-// are available only in Chrome and possible a good flag to indicate
-// that we're running in Chrome
-var isChrome = window.webkitRequestFileSystem && window.webkitResolveLocalFileSystemURL;
-
 // For chrome we don't need to implement proxy methods
 // All functionality can be accessed natively.
-if (isChrome) {
+if (require('./isChrome')()) {
     var pathsPrefix = {
         // Read-only directory where the application is installed.
         applicationDirectory: location.origin + "/",

--- a/www/browser/Preparing.js
+++ b/www/browser/Preparing.js
@@ -22,8 +22,7 @@
 /*global require*/
 
 //Only Chrome uses this file.
-var isChrome = window.webkitRequestFileSystem && window.webkitResolveLocalFileSystemURL;
-if (!isChrome) {
+if (!require('./isChrome')()) {
     return;
 }
 

--- a/www/browser/isChrome.js
+++ b/www/browser/isChrome.js
@@ -1,0 +1,26 @@
+/*
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *
+ */
+
+module.exports = function () {
+    // window.webkitRequestFileSystem and window.webkitResolveLocalFileSystemURL are available only in Chrome and
+    // possibly a good flag to indicate that we're running in Chrome
+    return window.webkitRequestFileSystem && window.webkitResolveLocalFileSystemURL;
+};

--- a/www/requestFileSystem.js
+++ b/www/requestFileSystem.js
@@ -21,13 +21,15 @@
 
 //For browser platform: not all browsers use this file.
 function checkBrowser() {
-    if (cordova.platformId === "browser" && navigator.userAgent.search(/Chrome/) > 0) {
-        var requestFileSystem  = window.requestFileSystem || window.webkitRequestFileSystem;
-        module.exports = requestFileSystem;
-        return;
+    if (cordova.platformId === "browser" && require('./isChrome')()) {
+        module.exports = window.requestFileSystem || window.webkitRequestFileSystem;
+        return true;
     }
+    return false;
 }
-checkBrowser();
+if (checkBrowser()) {
+    return;
+}
 
 var argscheck = require('cordova/argscheck'),
     FileError = require('./FileError'),

--- a/www/resolveLocalFileSystemURI.js
+++ b/www/resolveLocalFileSystemURI.js
@@ -21,13 +21,15 @@
 
 //For browser platform: not all browsers use overrided `resolveLocalFileSystemURL`.
 function checkBrowser() {
-    if (cordova.platformId === "browser" && navigator.userAgent.search(/Chrome/) > 0) {
-        var resolveLocalFileSystemURL  = window.resolveLocalFileSystemURL || window.webkitResolveLocalFileSystemURL;
-        module.exports.resolveLocalFileSystemURL = resolveLocalFileSystemURL;
-        return;
+    if (cordova.platformId === "browser" && require('./isChrome')()) {
+        module.exports.resolveLocalFileSystemURL = window.resolveLocalFileSystemURL || window.webkitResolveLocalFileSystemURL;
+        return true;
     }
+    return false;
 }
-checkBrowser();
+if (checkBrowser()) {
+    return;
+}
 
 var argscheck = require('cordova/argscheck'),
     DirectoryEntry = require('./DirectoryEntry'),


### PR DESCRIPTION
We shouldn't be patching `requestFileSystem` and `resolveLocalFileSystem` on Chrome. Recent change broke the existing logic for this.

Also, added common logic for detecting Chrome (or really, feature detection) so we are checking in a consistent manner.