### PR TITLE
Adding support of ApplicationData.SharedLocalFolder

### DIFF
--- a/src/windows/FileProxy.js
+++ b/src/windows/FileProxy.js
@@ -201,6 +201,12 @@ function getAllFS() {
                 name: 'root', 
                 //nativeURL: 'file:///'
                 winpath: ''
+            })),
+            'shared':
+            Object.freeze(new WinFS('shared', {
+            	name: 'shared',
+                nativeURL: nativePathToCordova(Windows.Storage.ApplicationData.current.sharedLocalFolder.path),
+                winpath: nativePathToCordova(Windows.Storage.ApplicationData.current.sharedLocalFolder.path)
             }))
         };
     }


### PR DESCRIPTION
Windows 10 introduced the ApplicationData.SharedLocalFolder property for Univeral apps. This folder allows to share data between users of the same device.
It is referring to the following path:
C:\ProgramData\Microsoft\Windows\AppRepository\Families\{package}\SharedLocal

This folder was not defined in all file systems in FileProxy.js for windows. So I added it to be able to use it.

