### PR TITLE
Fix for CB-9753 : index out of bounds on requestFileSystem

### DIFF
--- a/src/ios/CDVFile.m
+++ b/src/ios/CDVFile.m
@@ -448,7 +448,7 @@ NSString* const kCDVFilesystemURLPrefix = @"cdvfile";
     int type = [strType intValue];
     CDVPluginResult* result = nil;
 
-    if (type > self.fileSystems.count) {
+    if (type >= self.fileSystems.count) {
         result = [CDVPluginResult resultWithStatus:CDVCommandStatus_ERROR messageAsInt:NOT_FOUND_ERR];
         NSLog(@"No filesystem of type requested");
     } else {


### PR DESCRIPTION
This for the CB-9753, "index out of bounds on requestFileSystem".

Changed
 if (type > self.fileSystems.count) {

To
if (type >= self.fileSystems.count) {