### PR TITLE
CB-10577: Android resolveLocalFileSystemURL should detect directory

### DIFF
--- a/src/android/LocalFilesystem.java
+++ b/src/android/LocalFilesystem.java
@@ -93,7 +93,7 @@ public class LocalFilesystem extends Filesystem {
         if (!subPath.isEmpty()) {
             b.appendEncodedPath(subPath);
         }
-        if (f.isDirectory() || inputURL.getPath().endsWith("/")) {
+        if (f.isDirectory()) {
             // Add trailing / for directories.
             b.appendEncodedPath("");
         }

--- a/tests/tests.js
+++ b/tests/tests.js
@@ -301,6 +301,8 @@ exports.defineAutoTests = function () {
                     var fileName = 'file.spec.9';
                     var win = function (fileEntry) {
                         expect(fileEntry).toBeDefined();
+                        expect(fileEntry.isFile).toBe(true);
+                        expect(fileEntry.isDirectory).toBe(false);
                         expect(fileEntry.name).toCanonicallyMatch(fileName);
                         expect(fileEntry.toURL()).not.toMatch(/^cdvfile:/, 'should not use cdvfile URL');
                         expect(fileEntry.toURL()).not.toMatch(/\/$/, 'URL should not end with a slash');
@@ -311,10 +313,29 @@ exports.defineAutoTests = function () {
                         window.resolveLocalFileSystemURL(entry.toURL(), win, failed.bind(null, done, 'window.resolveLocalFileSystemURL - Error resolving file URL: ' + entry.toURL()));
                     }, failed.bind(null, done, 'createFile - Error creating file: ' + fileName), failed.bind(null, done, 'createFile - Error creating file: ' + fileName));
                 });
+                it("file.spec.9.1 should resolve a file even with a terminating slash", function (done) {
+                    var fileName = 'file.spec.9.1';
+                    var win = function (fileEntry) {
+                        expect(fileEntry).toBeDefined();
+                        expect(fileEntry.isFile).toBe(true);
+                        expect(fileEntry.isDirectory).toBe(false);
+                        expect(fileEntry.name).toCanonicallyMatch(fileName);
+                        expect(fileEntry.toURL()).not.toMatch(/^cdvfile:/, 'should not use cdvfile URL');
+                        expect(fileEntry.toURL()).not.toMatch(/\/$/, 'URL should not end with a slash');
+                        // Clean-up
+                        deleteEntry(fileName, done);
+                    };
+                    createFile(fileName, function (entry) {
+                        var entryURL = entry.toURL() + '/';
+                        window.resolveLocalFileSystemURL(entryURL, win, failed.bind(null, done, 'window.resolveLocalFileSystemURL - Error resolving file URL: ' + entryURL));
+                    }, failed.bind(null, done, 'createFile - Error creating file: ' + fileName), failed.bind(null, done, 'createFile - Error creating file: ' + fileName));
+                });
                 it("file.spec.9.5 should resolve a directory", function (done) {
                     var fileName = 'file.spec.9.5';
                     var win = function (fileEntry) {
                         expect(fileEntry).toBeDefined();
+                        expect(fileEntry.isFile).toBe(false);
+                        expect(fileEntry.isDirectory).toBe(true);
                         expect(fileEntry.name).toCanonicallyMatch(fileName);
                         expect(fileEntry.toURL()).not.toMatch(/^cdvfile:/, 'should not use cdvfile URL');
                         expect(fileEntry.toURL()).toMatch(/\/$/, 'URL end with a slash');
@@ -324,6 +345,26 @@ exports.defineAutoTests = function () {
                     function gotDirectory(entry) {
                         // lookup file system entry
                         window.resolveLocalFileSystemURL(entry.toURL(), win, failed.bind(null, done, 'window.resolveLocalFileSystemURL - Error resolving directory URL: ' + entry.toURL()));
+                    }
+                    createDirectory(fileName, gotDirectory, failed.bind(null, done, 'createDirectory - Error creating directory: ' + fileName), failed.bind(null, done, 'createDirectory - Error creating directory: ' + fileName));
+                });
+                it("file.spec.9.6 should resolve a directory even without a terminating slash", function (done) {
+                    var fileName = 'file.spec.9.6';
+                    var win = function (fileEntry) {
+                        expect(fileEntry).toBeDefined();
+                        expect(fileEntry.isFile).toBe(false);
+                        expect(fileEntry.isDirectory).toBe(true);
+                        expect(fileEntry.name).toCanonicallyMatch(fileName);
+                        expect(fileEntry.toURL()).not.toMatch(/^cdvfile:/, 'should not use cdvfile URL');
+                        expect(fileEntry.toURL()).toMatch(/\/$/, 'URL end with a slash');
+                        // cleanup
+                        deleteEntry(fileName, done);
+                    };
+                    function gotDirectory(entry) {
+                        // lookup file system entry
+                        var entryURL = entry.toURL();
+                        entryURL = entryURL.substring(0, entryURL.length - 1);
+                        window.resolveLocalFileSystemURL(entryURL, win, failed.bind(null, done, 'window.resolveLocalFileSystemURL - Error resolving directory URL: ' + entryURL));
                     }
                     createDirectory(fileName, gotDirectory, failed.bind(null, done, 'createDirectory - Error creating directory: ' + fileName), failed.bind(null, done, 'createDirectory - Error creating directory: ' + fileName));
                 });
@@ -545,7 +586,6 @@ exports.defineAutoTests = function () {
 
                 var fileName = "de:invalid:path",
                 fail = function (error) {
-                    console.error(error);
                     expect(error).toBeDefined();
                     expect(error).toBeFileError(FileError.ENCODING_ERR);
                     done();


### PR DESCRIPTION
@rakatyal or @riknoll please review

There were two places in the Android file plugin code that didn't do the right thing when resolving a URI whose trailing slash didn't match the directory vs file status.

1. In LocalFileSystem.toLocalUri(), the returned path should never have a terminating slash if the path does not point to a directory.

2. In FileUtils.resolveLocalFileSystemUri(), resolving a cdvfile:// (aka "local") URI now converts to native URI and back to a local URI (making use of the change above) in order to force resolution of whether the path points to a file or a directory and fix the terminating slash character accordingly. This is only done for local URIs, because for native URIs the resolveNativeUri() call would already have called toLocalUri() so doing it again would be redundant in that case.

I added automated test cases for resolving native URI files and directories using mismatched trailing slashes. As for cdvfile:// URIs, we currently only have manual test cases for those (at the bottom of tests.js) and they aren't very thorough. I manually tested this fix with cdvfile:// URIs.