### PR TITLE
CB-10577: Windows resolveLocalFileSystemURL should omit trailing slash for file

### DIFF
--- a/www/FileEntry.js
+++ b/www/FileEntry.js
@@ -36,7 +36,15 @@ var utils = require('cordova/utils'),
  * {FileSystem} filesystem on which the file resides (readonly)
  */
 var FileEntry = function(name, fullPath, fileSystem, nativeURL) {
-     FileEntry.__super__.constructor.apply(this, [true, false, name, fullPath, fileSystem, nativeURL]);
+    // remove trailing slash if it is present
+    if (fullPath && /\/$/.test(fullPath)) {
+        fullPath = fullPath.substring(0, fullPath.length - 1);
+    }
+    if (nativeURL && /\/$/.test(nativeURL)) {
+        nativeURL = nativeURL.substring(0, nativeURL.length - 1);
+    }
+
+    FileEntry.__super__.constructor.apply(this, [true, false, name, fullPath, fileSystem, nativeURL]);
 };
 
 utils.extend(FileEntry, Entry);


### PR DESCRIPTION
The FileEntry constructor should remove any trailing slash from its path. This parallels the existing DirectoryEntry constructor code which adds a trailing slash if missing.

This is actually not a Windows-specific fix, but it fixes a file plugin test case failure that was observed on Windows after I recently added that test case to validate an Android fix. Windows already invokes the correct FileEntry/DirEntry constructor based on the actual file/directory status of the path, so fixing the trailing slash is all that is needed.

@riknoll or @rakatyal please review