### PR TITLE
CB-10317 Encoded # in uri parse

### DIFF
--- a/src/android/FileUtils.java
+++ b/src/android/FileUtils.java
@@ -86,6 +86,9 @@ public class FileUtils extends CordovaPlugin {
 
     private CallbackContext callback;
 
+    public  static final String HASH="#";
+    public static final  String HASH_ENCODE="%23";
+
     /*
      * We need both read and write when accessing the storage, I think.
      */
@@ -407,7 +410,7 @@ public class FileUtils extends CordovaPlugin {
         else if (action.equals("resolveLocalFileSystemURI")) {
             threadhelper( new FileOp( ){
                 public void run(JSONArray args) throws IOException, JSONException {
-                    String fname=args.getString(0);
+                    String fname = encodeHashUri(args.getString(0));
                     JSONObject obj = resolveLocalFileSystemURI(fname);
                     callbackContext.success(obj);
                 }
@@ -1197,5 +1200,17 @@ public class FileUtils extends CordovaPlugin {
 
         }
 
+    }
+
+    /**
+     *
+     * @param uri Uri to encode '#'
+     * @return @return Encoded uri to '#' , since URI class not parse this char.
+     */
+    public static String encodeHashUri(String uri){
+        if (uri!=null){
+            uri = uri.replaceAll(FileUtils.HASH,FileUtils.HASH_ENCODE);
+        }
+        return uri;
     }
 }

--- a/src/android/LocalFilesystemURL.java
+++ b/src/android/LocalFilesystemURL.java
@@ -54,8 +54,9 @@ public class LocalFilesystemURL {
         return new LocalFilesystemURL(uri, fsName, path, isDirectory);
     }
 
+    // Encode '#' before parse uri since URI class not handle '#'
     public static LocalFilesystemURL parse(String uri) {
-        return parse(Uri.parse(uri));
+        return parse(Uri.parse(FileUtils.encodeHashUri(uri)));
     }
 
     public String toString() {


### PR DESCRIPTION
If we use # in folder name or file name Uri is not able parse that path as of now.

As Uri class not parse # symbol (Uri class reserved that # as fragment identification so ) I have used encoded value of this symbol directly in `encodeHashUri `method.
 
Method `parse` used in many places to parse the Uri path , I have encoded # in that method too in order to avoid code break. 