### PR TITLE
CB-11115 android: Fixing test content provider

### DIFF
--- a/tests/src/android/TestContentProvider.java
+++ b/tests/src/android/TestContentProvider.java
@@ -50,10 +50,7 @@ public class TestContentProvider extends ContentProvider {
         try {
             File f = File.createTempFile("test-content-provider", ".tmp");
             resourceApi.copyResource(Uri.parse("file:///android_asset" + fileName), Uri.fromFile(f));
-            FileInputStream fis = new FileInputStream(f);
-            String thisIsDumb = fis.getFD().toString();
-            int fd = Integer.parseInt(thisIsDumb.substring("FileDescriptor[".length(), thisIsDumb.length() - 1));
-            return ParcelFileDescriptor.adoptFd(fd);
+            return ParcelFileDescriptor.open(f, ParcelFileDescriptor.MODE_READ_ONLY);
         } catch (FileNotFoundException e) {
             throw e;
         } catch (IOException e) {


### PR DESCRIPTION
Seems like `FileDescriptor.toString()` changed in Android N and it broke three of our tests. This removes our dependency on the output of that. Tested on N and Marshmallow.