### PR TITLE
CB-11305 Enable cdvfile: assets fs root for DOM requests

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,7 +162,7 @@ the `cordova.file.*` properties map to physical paths on a real device.
 
 | Device Path                                     | `cordova.file.*`            | `AndroidExtraFileSystems` | r/w? | persistent? | OS clears | private |
 |:------------------------------------------------|:----------------------------|:--------------------------|:----:|:-----------:|:---------:|:-------:|
-| `file:///android_asset/`                        | applicationDirectory        |                           | r    |     N/A     |     N/A   |   Yes   |
+| `file:///android_asset/`                        | applicationDirectory        | assets                    | r    |     N/A     |     N/A   |   Yes   |
 | `/data/data/<app-id>/`                          | applicationStorageDirectory | -                         | r/w  |     N/A     |     N/A   |   Yes   |
 | &nbsp;&nbsp;&nbsp;`cache`                       | cacheDirectory              | cache                     | r/w  |     Yes     |     Yes\* |   Yes   |
 | &nbsp;&nbsp;&nbsp;`files`                       | dataDirectory               | files                     | r/w  |     Yes     |     No    |   Yes   |
@@ -530,7 +530,7 @@ Android recognize a <preference> tag in `config.xml` which names the
 filesystems to be installed. By default, all file-system roots are enabled.
 
     <preference name="iosExtraFilesystems" value="library,library-nosync,documents,documents-nosync,cache,bundle,root" />
-    <preference name="AndroidExtraFilesystems" value="files,files-external,documents,sdcard,cache,cache-external,root" />
+    <preference name="AndroidExtraFilesystems" value="files,files-external,documents,sdcard,cache,cache-external,assets,root" />
 
 ### Android
 
@@ -539,6 +539,7 @@ filesystems to be installed. By default, all file-system roots are enabled.
 * `sdcard`: The global external file storage directory (this is the root of the SD card, if one is installed). You must have the `android.permission.WRITE_EXTERNAL_STORAGE` permission to use this.
 * `cache`: The application's internal cache directory
 * `cache-external`: The application's external cache directory
+* `assets`: The application's bundle (read-only)
 * `root`: The entire device filesystem
 
 Android also supports a special filesystem named "documents", which represents a "/Documents/" subdirectory within the "files" filesystem.

--- a/plugin.xml
+++ b/plugin.xml
@@ -129,6 +129,7 @@ to config.xml in order for the application to find previously stored files.
                 <param name="android-package" value="org.apache.cordova.file.FileUtils"/>
                 <param name="onload" value="true" />
             </feature>
+            <allow-navigation href="cdvfile:*" />
         </config-file>
 
         <config-file target="AndroidManifest.xml" parent="/*">

--- a/src/android/AssetFilesystem.java
+++ b/src/android/AssetFilesystem.java
@@ -265,7 +265,7 @@ public class AssetFilesystem extends Filesystem {
 
     @Override
     String filesystemPathForURL(LocalFilesystemURL url) {
-        return null;
+        return new File(rootUri.getPath(), url.path).toString();
     }
 
     @Override

--- a/src/android/FileUtils.java
+++ b/src/android/FileUtils.java
@@ -122,7 +122,7 @@ public class FileUtils extends CordovaPlugin {
     }
 
     protected String[] getExtraFileSystemsPreference(Activity activity) {
-        String fileSystemsStr = preferences.getString("androidextrafilesystems", "files,files-external,documents,sdcard,cache,cache-external,root");
+        String fileSystemsStr = preferences.getString("androidextrafilesystems", "files,files-external,documents,sdcard,cache,cache-external,assets,root");
         return fileSystemsStr.split(",");
     }
 


### PR DESCRIPTION
<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist
is intended as a quick reference, for complete details please see our Contributor Guidelines:

http://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->

### Platforms affected
Android

### What does this PR do?
Added test for `cdvfile` `applicationDirectory` fs root.
Updated the docs and added the `assets` to Android available fs roots list.

### What testing has been done on this change?
Jasmine auto and manual tests, app tests (see [Jira](https://issues.apache.org/jira/browse/CB-11305))
