### PR TITLE
CB-11385 android: Does not pass sonarqube scan

### DIFF
--- a/src/android/AssetFilesystem.java
+++ b/src/android/AssetFilesystem.java
@@ -45,6 +45,8 @@ public class AssetFilesystem extends Filesystem {
     private static Map<String, String[]> listCache;
     private static Map<String, Long> lengthCache;
 
+    private static final String LOG_TAG = "AssetFilesystem";
+
     private void lazyInitCaches() {
         synchronized (listCacheLock) {
             if (listCache == null) {
@@ -63,6 +65,7 @@ public class AssetFilesystem extends Filesystem {
                         try {
                             ois.close();
                         } catch (IOException e) {
+                            Log.d(LOG_TAG, e.getLocalizedMessage());
                         }
                     }
                 }
@@ -116,12 +119,15 @@ public class AssetFilesystem extends Filesystem {
             }
             return length;
         } catch (IOException e) {
-            throw new FileNotFoundException("File not found: " + assetPath);
+            FileNotFoundException fnfe = new FileNotFoundException("File not found: " + assetPath);
+            fnfe.initCause(e);
+            throw fnfe;
         } finally {
             if (offr != null) {
                 try {
                     offr.inputStream.close();
                 } catch (IOException e) {
+                    Log.d(LOG_TAG, e.getLocalizedMessage());
                 }
             }
         }
@@ -188,7 +194,9 @@ public class AssetFilesystem extends Filesystem {
         try {
             files = listAssets(pathNoSlashes);
         } catch (IOException e) {
-            throw new FileNotFoundException();
+            FileNotFoundException fnfe = new FileNotFoundException();
+            fnfe.initCause(e);
+            throw fnfe;
         }
 
         LocalFilesystemURL[] entries = new LocalFilesystemURL[files.length];

--- a/src/android/ContentFilesystem.java
+++ b/src/android/ContentFilesystem.java
@@ -98,7 +98,9 @@ public class ContentFilesystem extends Filesystem {
 			// Was seeing this on the File mobile-spec tests on 4.0.3 x86 emulator.
 			// The ContentResolver applies only when the file was registered in the
 			// first case, which is generally only the case with images.
-            throw new NoModificationAllowedException("Deleting not supported for content uri: " + contentUri);
+            NoModificationAllowedException nmae = new NoModificationAllowedException("Deleting not supported for content uri: " + contentUri);
+            nmae.initCause(t);
+            throw nmae;
 		}
         return true;
 	}
@@ -133,7 +135,9 @@ public class ContentFilesystem extends Filesystem {
     			size = offr.length;
         	}
         } catch (IOException e) {
-            throw new FileNotFoundException();
+            FileNotFoundException fnfe = new FileNotFoundException();
+            fnfe.initCause(e);
+            throw fnfe;
         } finally {
         	if (cursor != null)
         		cursor.close();

--- a/src/android/FileUtils.java
+++ b/src/android/FileUtils.java
@@ -625,7 +625,9 @@ public class FileUtils extends CordovaPlugin {
             }
             return fs.filesystemPathForURL(inputURL);
         } catch (IllegalArgumentException e) {
-            throw new MalformedURLException("Unrecognized filesystem URL");
+            MalformedURLException mue = new MalformedURLException("Unrecognized filesystem URL");
+            mue.initCause(e);
+        	throw mue;
         }
     }
 
@@ -728,7 +730,9 @@ public class FileUtils extends CordovaPlugin {
                 return fs.getEntryForLocalURL(inputURL);
             }
         } catch (IllegalArgumentException e) {
-            throw new MalformedURLException("Unrecognized filesystem URL");
+            MalformedURLException mue = new MalformedURLException("Unrecognized filesystem URL");
+            mue.initCause(e);
+        	throw mue;
         }
         throw new FileNotFoundException();
     }
@@ -751,7 +755,9 @@ public class FileUtils extends CordovaPlugin {
         	return fs.readEntriesAtLocalURL(inputURL);
 
         } catch (IllegalArgumentException e) {
-        	throw new MalformedURLException("Unrecognized filesystem URL");
+            MalformedURLException mue = new MalformedURLException("Unrecognized filesystem URL");
+            mue.initCause(e);
+        	throw mue;
         }
     }
 
@@ -814,7 +820,9 @@ public class FileUtils extends CordovaPlugin {
         	return fs.recursiveRemoveFileAtLocalURL(inputURL);
 
         } catch (IllegalArgumentException e) {
-        	throw new MalformedURLException("Unrecognized filesystem URL");
+            MalformedURLException mue = new MalformedURLException("Unrecognized filesystem URL");
+            mue.initCause(e);
+        	throw mue;
         }
     }
 
@@ -844,7 +852,9 @@ public class FileUtils extends CordovaPlugin {
         	return fs.removeFileAtLocalURL(inputURL);
 
         } catch (IllegalArgumentException e) {
-        	throw new MalformedURLException("Unrecognized filesystem URL");
+            MalformedURLException mue = new MalformedURLException("Unrecognized filesystem URL");
+            mue.initCause(e);
+        	throw mue;
         }
     }
 
@@ -872,7 +882,9 @@ public class FileUtils extends CordovaPlugin {
         	return fs.getFileForLocalURL(inputURL, path, options, directory);
 
         } catch (IllegalArgumentException e) {
-        	throw new MalformedURLException("Unrecognized filesystem URL");
+            MalformedURLException mue = new MalformedURLException("Unrecognized filesystem URL");
+            mue.initCause(e);
+        	throw mue;
         }
 
     }
@@ -891,7 +903,9 @@ public class FileUtils extends CordovaPlugin {
         	return fs.getParentForLocalURL(inputURL);
 
         } catch (IllegalArgumentException e) {
-        	throw new MalformedURLException("Unrecognized filesystem URL");
+            MalformedURLException mue = new MalformedURLException("Unrecognized filesystem URL");
+            mue.initCause(e);
+        	throw mue;
         }
     }
 
@@ -910,7 +924,9 @@ public class FileUtils extends CordovaPlugin {
         	return fs.getFileMetadataForLocalURL(inputURL);
 
         } catch (IllegalArgumentException e) {
-        	throw new MalformedURLException("Unrecognized filesystem URL");
+            MalformedURLException mue = new MalformedURLException("Unrecognized filesystem URL");
+            mue.initCause(e);
+        	throw mue;
         }
     }
 
@@ -1088,7 +1104,9 @@ public class FileUtils extends CordovaPlugin {
 
 
         } catch (IllegalArgumentException e) {
-        	throw new MalformedURLException("Unrecognized filesystem URL");
+            MalformedURLException mue = new MalformedURLException("Unrecognized filesystem URL");
+            mue.initCause(e);
+        	throw mue;
         } catch (FileNotFoundException e) {
         	callbackContext.sendPluginResult(new PluginResult(PluginResult.Status.IO_EXCEPTION, NOT_FOUND_ERR));
         } catch (IOException e) {
@@ -1116,7 +1134,9 @@ public class FileUtils extends CordovaPlugin {
 
             long x = fs.writeToFileAtURL(inputURL, data, offset, isBinary); Log.d("TEST",srcURLstr + ": "+x); return x;
         } catch (IllegalArgumentException e) {
-        	throw new MalformedURLException("Unrecognized filesystem URL");
+            MalformedURLException mue = new MalformedURLException("Unrecognized filesystem URL");
+            mue.initCause(e);
+        	throw mue;
         }
 
     }
@@ -1134,7 +1154,9 @@ public class FileUtils extends CordovaPlugin {
 
             return fs.truncateFileAtURL(inputURL, size);
         } catch (IllegalArgumentException e) {
-        	throw new MalformedURLException("Unrecognized filesystem URL");
+            MalformedURLException mue = new MalformedURLException("Unrecognized filesystem URL");
+            mue.initCause(e);
+        	throw mue;
         }
     }
 

--- a/src/android/LocalFilesystem.java
+++ b/src/android/LocalFilesystem.java
@@ -384,7 +384,7 @@ public class LocalFilesystem extends Filesystem {
         if (isBinary) {
             rawData = Base64.decode(data, Base64.DEFAULT);
         } else {
-            rawData = data.getBytes();
+            rawData = data.getBytes(Charset.defaultCharset());
         }
         ByteArrayInputStream in = new ByteArrayInputStream(rawData);
         try
@@ -408,6 +408,7 @@ public class LocalFilesystem extends Filesystem {
         {
             // This is a bug in the Android implementation of the Java Stack
             NoModificationAllowedException realException = new NoModificationAllowedException(inputURL.toString());
+            realException.initCause(e);
             throw realException;
         }
 


### PR DESCRIPTION
The problem are "Empty Catch Block", which sonarqube considers a blocker, and the
following, which sonarqube considers major:
Preserve stack trace, Reliance on default encoding.