### PR TITLE
CB-11407 (ios): Added extern keyword to constants to fix phonegap-webview-ios template projects

### DIFF
--- a/src/ios/CDVFile.h
+++ b/src/ios/CDVFile.h
@@ -20,8 +20,8 @@
 #import <Foundation/Foundation.h>
 #import <Cordova/CDVPlugin.h>
 
-NSString* const kCDVAssetsLibraryPrefix;
-NSString* const kCDVFilesystemURLPrefix;
+extern NSString* const kCDVAssetsLibraryPrefix;
+extern NSString* const kCDVFilesystemURLPrefix;
 
 enum CDVFileError {
     NO_ERROR = 0,


### PR DESCRIPTION
<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist
is intended as a quick reference, for complete details please see our Contributor Guidelines:

http://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->

### Platforms affected
iOS

### What does this PR do?
Fixes iOS embedded webview projects based on the [phonegap-webview-ios template](https://github.com/phonegap/phonegap-webview-ios/) due to the reasons explained in [CB-11407](https://issues.apache.org/jira/browse/CB-11407) and template [issue 8] (https://github.com/phonegap/phonegap-webview-ios/issues/8).

### What testing has been done on this change?
This change has been tested locally with iOS embedded webview projects based on [this template](https://github.com/phonegap/phonegap-webview-ios).  

### Checklist
- [X] [ICLA](http://www.apache.org/licenses/icla.txt) has been signed and submitted to secretary@apache.org.
- [X] [Reported an issue](http://cordova.apache.org/contribute/issues.html) in the JIRA database
- [X] Commit message follows the format: "CB-3232: (android) Fix bug with resolving file paths", where CB-xxxx is the JIRA ID & "android" is the platform affected.
- [X] Added automated test coverage as appropriate for this change.

