### PR TITLE
BugFix - Import java.nio.charset.Charset in LocalFileSystem class

### DIFF
--- a/src/android/LocalFilesystem.java
+++ b/src/android/LocalFilesystem.java
@@ -39,6 +39,8 @@ import android.net.Uri;
 import android.content.Context;
 import android.content.Intent;
 
+import java.nio.charset.Charset;
+
 public class LocalFilesystem extends Filesystem {
     private final Context context;
 


### PR DESCRIPTION
### Platforms affected
Android

### What does this PR do?
Because class LocalFilesystem needs java.nio.charset.Charset import

### What testing has been done on this change?
tested with Cordova 6.1.1

