### PR TITLE
CB-11305 Enable cdvfile: assets fs root for DOM requests

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,7 +164,7 @@ the `cordova.file.*` properties map to physical paths on a real device.
 
 | Device Path                                     | `cordova.file.*`            | `AndroidExtraFileSystems` | r/w? | persistent? | OS clears | private |
 |:------------------------------------------------|:----------------------------|:--------------------------|:----:|:-----------:|:---------:|:-------:|
-| `file:///android_asset/`                        | applicationDirectory        |                           | r    |     N/A     |     N/A   |   Yes   |
+| `file:///android_asset/`                        | applicationDirectory        | assets                    | r    |     N/A     |     N/A   |   Yes   |
 | `/data/data/<app-id>/`                          | applicationStorageDirectory | -                         | r/w  |     N/A     |     N/A   |   Yes   |
 | &nbsp;&nbsp;&nbsp;`cache`                       | cacheDirectory              | cache                     | r/w  |     Yes     |     Yes\* |   Yes   |
 | &nbsp;&nbsp;&nbsp;`files`                       | dataDirectory               | files                     | r/w  |     Yes     |     No    |   Yes   |
@@ -532,7 +532,7 @@ Android recognize a <preference> tag in `config.xml` which names the
 filesystems to be installed. By default, all file-system roots are enabled.
 
     <preference name="iosExtraFilesystems" value="library,library-nosync,documents,documents-nosync,cache,bundle,root" />
-    <preference name="AndroidExtraFilesystems" value="files,files-external,documents,sdcard,cache,cache-external,root" />
+    <preference name="AndroidExtraFilesystems" value="files,files-external,documents,sdcard,cache,cache-external,assets,root" />
 
 ### Android
 
@@ -541,6 +541,7 @@ filesystems to be installed. By default, all file-system roots are enabled.
 * `sdcard`: The global external file storage directory (this is the root of the SD card, if one is installed). You must have the `android.permission.WRITE_EXTERNAL_STORAGE` permission to use this.
 * `cache`: The application's internal cache directory
 * `cache-external`: The application's external cache directory
+* `assets`: The application's bundle (read-only)
 * `root`: The entire device filesystem
 
 Android also supports a special filesystem named "documents", which represents a "/Documents/" subdirectory within the "files" filesystem.

--- a/plugin.xml
+++ b/plugin.xml
@@ -129,6 +129,7 @@ to config.xml in order for the application to find previously stored files.
                 <param name="android-package" value="org.apache.cordova.file.FileUtils"/>
                 <param name="onload" value="true" />
             </feature>
+            <allow-navigation href="cdvfile:*" />
         </config-file>
 
         <config-file target="AndroidManifest.xml" parent="/*">

--- a/src/android/AssetFilesystem.java
+++ b/src/android/AssetFilesystem.java
@@ -273,7 +273,7 @@ public class AssetFilesystem extends Filesystem {
 
     @Override
     String filesystemPathForURL(LocalFilesystemURL url) {
-        return null;
+        return new File(rootUri.getPath(), url.path).toString();
     }
 
     @Override

--- a/src/android/FileUtils.java
+++ b/src/android/FileUtils.java
@@ -122,7 +122,7 @@ public class FileUtils extends CordovaPlugin {
     }
 
     protected String[] getExtraFileSystemsPreference(Activity activity) {
-        String fileSystemsStr = preferences.getString("androidextrafilesystems", "files,files-external,documents,sdcard,cache,cache-external,root");
+        String fileSystemsStr = preferences.getString("androidextrafilesystems", "files,files-external,documents,sdcard,cache,cache-external,assets,root");
         return fileSystemsStr.split(",");
     }
 

--- a/tests/tests.js
+++ b/tests/tests.js
@@ -3441,6 +3441,46 @@ exports.defineAutoTests = function () {
                 }
             });
         });
+        describe('resolveLocalFileSystemURL on cdvfile://', function () {
+            it("file.spec.147 should be able to resolve cdvfile applicationDirectory fs root", function(done) {
+                var cdvfileApplicationDirectoryFsRootName;
+                if (cordova.platformId === 'android') {
+                    cdvfileApplicationDirectoryFsRootName = 'assets';
+                } else if (cordova.platformId === 'ios') {
+                    cdvfileApplicationDirectoryFsRootName = 'bundle';
+                } else {
+                    pending();
+                }
+
+                resolveLocalFileSystemURL('cdvfile://localhost/' + cdvfileApplicationDirectoryFsRootName + '/', function(applicationDirectoryRoot) {
+                    expect(applicationDirectoryRoot.isFile).toBe(false);
+                    expect(applicationDirectoryRoot.isDirectory).toBe(true);
+                    expect(applicationDirectoryRoot.name).toCanonicallyMatch('');
+                    expect(applicationDirectoryRoot.fullPath).toCanonicallyMatch('/');
+                    expect(applicationDirectoryRoot.filesystem.name).toEqual(cdvfileApplicationDirectoryFsRootName);
+
+                    // Requires HelloCordova www assets, <allow-navigation href="cdvfile:*" /> in config.xml or
+                    // cdvfile: in CSP and <access origin="cdvfile://*" /> in config.xml
+                    resolveLocalFileSystemURL('cdvfile://localhost/' + cdvfileApplicationDirectoryFsRootName + '/www/img/logo.png', function(entry) {
+                        expect(entry.isFile).toBe(true);
+                        expect(entry.isDirectory).toBe(false);
+                        expect(entry.name).toCanonicallyMatch('logo.png');
+                        expect(entry.fullPath).toCanonicallyMatch('/www/img/logo.png');
+                        expect(entry.filesystem.name).toEqual(cdvfileApplicationDirectoryFsRootName);
+
+                        var img = new Image();
+                        img.onerror = function(err) {
+                            expect(err).not.toBeDefined();
+                            done();
+                        };
+                        img.onload = function() {
+                            done();
+                        };
+                        img.src = entry.toInternalURL();
+                    }, failed.bind(null, done, 'resolveLocalFileSystemURL failed for cdvfile applicationDirectory'));
+                }, failed.bind(null, done, 'resolveLocalFileSystemURL failed for cdvfile applicationDirectory'));
+            });
+        });
         //cross-file-system copy and move
         describe('IndexedDB-based impl', function () {
             it("file.spec.131 Nested file or nested directory should be removed when removing a parent directory", function (done) {
@@ -3576,6 +3616,7 @@ exports.defineAutoTests = function () {
         // Content and Asset URLs
         if (cordova.platformId == 'android') {
             describe('content: URLs', function() {
+                // Warning: Default HelloWorld www directory structure is required for these tests (www/index.html at least)
                 function testContentCopy(src, done) {
                     var file2 = "entry.copy.file2b",
                     fullPath = joinURL(temp_root.fullPath, file2),
@@ -3786,7 +3827,7 @@ exports.defineManualTests = function (contentEl, createActionButton) {
     var fsRoots = {
         "ios" : "library,library-nosync,documents,documents-nosync,cache,bundle,root,private",
         "osx" : "library,library-nosync,documents,documents-nosync,cache,bundle,root,private",
-        "android" : "files,files-external,documents,sdcard,cache,cache-external,root",
+        "android" : "files,files-external,documents,sdcard,cache,cache-external,assets,root",
         "amazon-fireos" : "files,files-external,documents,sdcard,cache,cache-external,root",
         "windows": "temporary,persistent"
     };


### PR DESCRIPTION
<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist
is intended as a quick reference, for complete details please see our Contributor Guidelines:

http://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->

### Platforms affected
Android

### What does this PR do?
* Added test for cdvfile applicationDirectory fs root
* Updated the docs and added the assets to Android available fs roots list
* Allow cdvfile: access for android automatically

### What testing has been done on this change?
Jasmine auto and manual tests, app tests (see [Jira](https://issues.apache.org/jira/browse/CB-11305))

### Checklist
- [x] [ICLA](http://www.apache.org/licenses/icla.txt) has been signed and submitted to secretary@apache.org.
- [x] [Reported an issue](http://cordova.apache.org/contribute/issues.html) in the JIRA database
- [x] Commit message follows the format: "CB-3232: (android) Fix bug with resolving file paths", where CB-xxxx is the JIRA ID & "android" is the platform affected.
- [x] Added automated test coverage as appropriate for this change.