### PR TITLE
CB-11598: (iOS) Fix iOS base64 output having newline chars

### DIFF
--- a/src/ios/CDVFile.m
+++ b/src/ios/CDVFile.m
@@ -25,7 +25,7 @@
 
 static NSString* toBase64(NSData* data) {
     SEL s1 = NSSelectorFromString(@"cdv_base64EncodedString");
-    SEL s2 = NSSelectorFromString(@"base64EncodedString");
+    SEL s2 = NSSelectorFromString(@"base64EncodedStringWithSeparateLines:false");
     SEL s3 = NSSelectorFromString(@"base64EncodedStringWithOptions:");
     
     if ([data respondsToSelector:s1]) {


### PR DESCRIPTION
<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist
is intended as a quick reference, for complete details please see our Contributor Guidelines:

http://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->

### Platforms affected
iOS

### What does this PR do?
Makes the base64 output omit newline chars. This makes it consistent with the Android implementation and allows the base64 output to inputted into an NSData initWithBase64EncodedString: without any workarounds.

### What testing has been done on this change?
Output data has been used to generate object URLs for images on a page and to send to Instagram using the cordova-instagram-plugin (Which simply takes the data and uses it to write an image file).

### Checklist
- [x] [ICLA](http://www.apache.org/licenses/icla.txt) has been signed and submitted to secretary@apache.org.
- [x] [Reported an issue](http://cordova.apache.org/contribute/issues.html) in the JIRA database
- [x] Commit message follows the format: "CB-3232: (android) Fix bug with resolving file paths", where CB-xxxx is the JIRA ID & "android" is the platform affected.
- [ ] Added automated test coverage as appropriate for this change.