### PR TITLE
Fix .DS_Store bug on mac os #android

### DIFF
--- a/src/android/build-extras.gradle
+++ b/src/android/build-extras.gradle
@@ -24,12 +24,22 @@ ext.postBuildExtras = {
     def newTask = task("cdvCreateAssetManifest") << {
         def contents = new HashMap()
         def sizes = new HashMap()
-        contents[""] = inAssetsDir.list()
+        contents[""] = inAssetsDir.list(new FilenameFilter() {
+            @Override
+            public boolean accept(File dir, String name) {
+                return !name.equals(".DS_Store");
+            }
+        })
         def tree = fileTree(dir: inAssetsDir)
         tree.visit { fileDetails ->
             if (fileDetails.isDirectory()) {
-                contents[fileDetails.relativePath.toString()] = fileDetails.file.list()
-            } else {
+                contents[fileDetails.relativePath.toString()] = fileDetails.file.list(new FilenameFilter() {
+                    @Override
+                    public boolean accept(File dir, String name) {
+                        return !name.equals(".DS_Store");
+                    }
+                })
+            } else if (fileDetails.name) {
                 sizes[fileDetails.relativePath.toString()] = fileDetails.file.length()
             }
         }


### PR DESCRIPTION
### Platforms affected
Android

### What does this PR do?
On mac os gradle extras make .DS_Store files in cache, but they is unavailable in runtime.  By this reason a have error if trying to copy directory from assets folder.

### What testing has been done on this change?
compiled and tested on my android devices.

### Checklist
This check list is to hard to me.

- [ ] [ICLA](http://www.apache.org/licenses/icla.txt) has been signed and submitted to secretary@apache.org.
- [ ] [Reported an issue](http://cordova.apache.org/contribute/issues.html) in the JIRA database
- [ ] Commit message follows the format: "CB-3232: (android) Fix bug with resolving file paths", where CB-xxxx is the JIRA ID & "android" is the platform affected.
- [ ] Added automated test coverage as appropriate for this change.
