### PR TITLE
CB-11693 ios: Make possible to run copy and move operations in the background thread

### DIFF
--- a/src/ios/CDVFile.m
+++ b/src/ios/CDVFile.m
@@ -797,8 +797,10 @@ NSString* const kCDVFilesystemURLPrefix = @"cdvfile";
     }
 
     __weak CDVFile* weakSelf = self;
-    [destFs copyFileToURL:destURL withName:newName fromFileSystem:srcFs atURL:srcURL copy:bCopy callback:^(CDVPluginResult* result) {
-        [weakSelf.commandDelegate sendPluginResult:result callbackId:command.callbackId];
+    [self.commandDelegate runInBackground:^ {
+        [destFs copyFileToURL:destURL withName:newName fromFileSystem:srcFs atURL:srcURL copy:bCopy callback:^(CDVPluginResult* result) {
+            [weakSelf.commandDelegate sendPluginResult:result callbackId:command.callbackId];
+        }];
     }];
 
 }


### PR DESCRIPTION
<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist
is intended as a quick reference, for complete details please see our Contributor Guidelines:

http://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->

### Platforms affected
ios

### What does this PR do?
Callback within doCopyMove method was executed in main thread. PR lets to avoid 'THREAD WARNING' message, because it makes callback  execution in the background thread.

### Checklist
- [x] [ICLA](http://www.apache.org/licenses/icla.txt) has been signed and submitted to secretary@apache.org.
- [x] [Reported an issue](http://cordova.apache.org/contribute/issues.html) in the JIRA database
- [x] Commit message follows the format: "CB-3232: (android) Fix bug with resolving file paths", where CB-xxxx is the JIRA ID & "android" is the platform affected.
- [ ] Added automated test coverage as appropriate for this change.

… background thread