### PR TITLE
CB-11699 Read files as Data URLs properly

### DIFF
--- a/tests/tests.js
+++ b/tests/tests.js
@@ -2469,7 +2469,41 @@ exports.defineAutoTests = function () {
                     },
                     0, -1, largeText);
             });
-       });
+            it("file.spec.94.6 should read large file in multiple chunks, readAsDataURL", function (done) {
+                var largeText = "";
+                for (var i = 0; i < 10; i++) {
+                    largeText += "Test " + i + "\n";
+                }
+
+                // Set the chunk size so that the read will take 5 chunks
+                FileReader.READ_CHUNK_SIZE = Math.floor(largeText.length / 4) + 1;
+
+                var lastProgressValue = 0;
+                var progressFunc = function (evt) {
+                    expect(evt.total).toBeDefined();
+                    expect(evt.total).toEqual(largeText.length);
+
+                    expect(evt.loaded).toBeDefined();
+                    expect(evt.loaded).toBeGreaterThan(lastProgressValue);
+                    expect(evt.loaded).toBeLessThan(evt.total + 1);
+
+                    lastProgressValue = evt.loaded;
+                };
+
+                runReaderTest('readAsDataURL', false, done, progressFunc,
+                    function (evt, fileData, fileDataAsBinaryString) {
+                        expect(function () {
+                            // Cut off data uri prefix
+                            var base64Data = evt.target.result.substring(evt.target.result.indexOf(',') + 1);
+                            expect(window.atob(base64Data)).toEqual(fileData);
+                        }).not.toThrow();
+
+                        expect(lastProgressValue).toEqual(largeText.length);
+                        done();
+                    },
+                undefined, undefined, largeText);
+            });
+        });
         //Read method
         describe('FileWriter', function () {
             it("file.spec.95 should have correct methods", function (done) {

--- a/www/FileReader.js
+++ b/www/FileReader.js
@@ -121,9 +121,19 @@ function readSuccessCallback(readType, encoding, offset, totalSize, accumulate, 
         return;
     }
 
+    var CHUNK_SIZE = FileReader.READ_CHUNK_SIZE;
+    if (readType === 'readAsDataURL') {
+        // Windows proxy does not support reading file slices as Data URLs
+        // so read the whole file at once.
+        CHUNK_SIZE = cordova.platformId === 'windows' ? totalSize :
+            // Calculate new chunk size for data URLs to be multiply of 3
+            // Otherwise concatenated base64 chunks won't be valid base64 data
+            FileReader.READ_CHUNK_SIZE - (FileReader.READ_CHUNK_SIZE % 3) + 3;
+    }
+
     if (typeof r !== "undefined") {
         accumulate(r);
-        this._progress = Math.min(this._progress + FileReader.READ_CHUNK_SIZE, totalSize);
+        this._progress = Math.min(this._progress + CHUNK_SIZE, totalSize);
 
         if (typeof this.onprogress === "function") {
             this.onprogress(new ProgressEvent("progress", {loaded:this._progress, total:totalSize}));
@@ -134,7 +144,7 @@ function readSuccessCallback(readType, encoding, offset, totalSize, accumulate, 
         var execArgs = [
             this._localURL,
             offset + this._progress,
-            offset + this._progress + Math.min(totalSize - this._progress, FileReader.READ_CHUNK_SIZE)];
+            offset + this._progress + Math.min(totalSize - this._progress, CHUNK_SIZE)];
         if (encoding) {
             execArgs.splice(1, 0, encoding);
         }


### PR DESCRIPTION
<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist
is intended as a quick reference, for complete details please see our Contributor Guidelines:

http://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->

### Platforms affected
Android, iOS, Windows

### What does this PR do?
This PR fixes reading files as data URLs by modifying chunk size, so concatenated chunks would be a valid Data URL

### What testing has been done on this change?
Ran plugin tests on all affected platforms


### Checklist
- [x] [ICLA](http://www.apache.org/licenses/icla.txt) has been signed and submitted to secretary@apache.org.
- [x] [Reported an issue](http://cordova.apache.org/contribute/issues.html) in the JIRA database
- [x] Commit message follows the format: "CB-3232: (android) Fix bug with resolving file paths", where CB-xxxx is the JIRA ID & "android" is the platform affected.
- [x] Added automated test coverage as appropriate for this change.

When reading file as Data URL, CHUNK_SIZE must be divisible by 3, otherwise the resultant string, made by concatenating chunks, will not be a valid Base64 encoded Data URL. Also Windows do not support reading sliced files as data URLs, so we need to set chunk size equal to file size.

Relevant JIRA issues: [CB-11699](https://issues.apache.org/jira/browse/CB-11699), [CB-11199](https://issues.apache.org/jira/browse/CB-11199)