### PR TITLE
CB-11368 android: Resolve content URLs produced by contacts plugin

### DIFF
--- a/src/android/ContentFilesystem.java
+++ b/src/android/ContentFilesystem.java
@@ -124,16 +124,19 @@ public class ContentFilesystem extends Filesystem {
         String mimeType = resourceApi.getMimeType(nativeUri);
         Cursor cursor = openCursorForURL(nativeUri);
         try {
-        	if (cursor != null && cursor.moveToFirst()) {
-        		size = resourceSizeForCursor(cursor);
+            if (cursor != null && cursor.moveToFirst()) {
+                Long sizeForCursor = resourceSizeForCursor(cursor);
+                if (sizeForCursor != null) {
+                    size = sizeForCursor.longValue();
+                }
                 Long modified = lastModifiedDateForCursor(cursor);
                 if (modified != null)
                     lastModified = modified.longValue();
-        	} else {
+            } else {
                 // Some content providers don't support cursors at all!
                 CordovaResourceApi.OpenForReadResult offr = resourceApi.openForRead(nativeUri);
-    			size = offr.length;
-        	}
+                size = offr.length;
+            }
         } catch (IOException e) {
             FileNotFoundException fnfe = new FileNotFoundException();
             fnfe.initCause(e);

--- a/tests/plugin.xml
+++ b/tests/plugin.xml
@@ -39,5 +39,6 @@
                 android:exported="false" />
         </config-file>
         <asset src="www/fixtures/asset-test" target="fixtures/asset-test" />
+        <dependency id="cordova-plugin-contacts" />
     </platform>
 </plugin>

--- a/tests/tests.js
+++ b/tests/tests.js
@@ -3803,6 +3803,37 @@ exports.defineManualTests = function (contentEl, createActionButton) {
         }, logError("requestFileSystem"));
     }
 
+    function resolveFsContactImage() {
+        navigator.contacts.pickContact(function(contact) {
+            var logBox = document.getElementById("logContactBox");
+            logBox.innerHTML = "";
+            var resolveResult = document.createElement("p");
+            if (contact.photos) {
+                var photoURL = contact.photos[0].value;
+                resolveLocalFileSystemURL(photoURL, function(entry) {
+                    var contactImage = document.createElement("img");
+                    var contactLabelImage = document.createElement("p");                       
+                    contactLabelImage.innerHTML = "Result contact image";                   
+                    contactImage.setAttribute("src", entry.toURL());
+                    resolveResult.innerHTML = "Success resolve\n" + entry.toURL();
+                    logBox.appendChild(contactLabelImage);
+                    logBox.appendChild(contactImage);
+                    logBox.appendChild(resolveResult);
+                }, 
+                function(err) {
+                    console.log("resolve error" + err);
+                }); 
+            }
+            else {
+                resolveResult.innerHTML = "Contact has no photos";
+                logBox.appendChild(resolveResult);
+            }
+        }, 
+        function(err) {
+            console.log("contact pick error" + err);
+        });
+    }    
+
     function clearLog() {
         var log = document.getElementById("info");
         log.innerHTML = "";
@@ -3880,4 +3911,23 @@ exports.defineManualTests = function (contentEl, createActionButton) {
         'should be successfully resolved. Status box should say Successfully resolved. Both blue URLs below ' +
         'that should match.'));
     contentEl.appendChild(div);
+
+    div = document.createElement('h2');
+    div.appendChild(document.createTextNode('Resolving content urls'));
+    div.setAttribute("align", "center");
+    contentEl.appendChild(div);
+
+    div = document.createElement('div');
+    div.setAttribute("id", "contactButton");
+    div.setAttribute("align", "center");
+    contentEl.appendChild(div);
+
+    div = document.createElement('div');
+    div.setAttribute("id", "logContactBox");
+    div.setAttribute("align", "center");
+    contentEl.appendChild(div);
+
+    createActionButton('show-contact-image', function () {
+        resolveFsContactImage();
+    }, 'contactButton');    
 };


### PR DESCRIPTION
<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist
is intended as a quick reference, for complete details please see our Contributor Guidelines:

http://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->

### Platforms affected
Android

### What does this PR do?
This PR does a safe assigment of returning value from resourceSizeForCursor to variable 'size'.

### What testing has been done on this change?
Manual testing

### Checklist
- [x] [ICLA](http://www.apache.org/licenses/icla.txt) has been signed and submitted to secretary@apache.org.
- [x] [Reported an issue](http://cordova.apache.org/contribute/issues.html) in the JIRA database
- [x] Commit message follows the format: "CB-3232: (android) Fix bug with resolving file paths", where CB-xxxx is the JIRA ID & "android" is the platform affected.
- [ ] Added automated test coverage as appropriate for this change.

This bug was happening because of invalid assignment of null value to variable of primitive type