### PR TITLE
CB-10706: (windows) fix ENCODING_ERR for applicationDirectory

### DIFF
--- a/src/windows/FileProxy.js
+++ b/src/windows/FileProxy.js
@@ -195,6 +195,12 @@ function getAllFS() {
                 nativeURL: 'ms-appdata:///temp',
                 winpath: nativePathToCordova(Windows.Storage.ApplicationData.current.temporaryFolder.path)
             })),
+            'application':
+            Object.freeze(new WinFS('application', { 
+                name: 'application', 
+                nativeURL: 'ms-appx:///',
+                winpath: nativePathToCordova(Windows.ApplicationModel.Package.current.installedLocation.path)
+            })),
             'root':
             Object.freeze(new WinFS('root', { 
                 name: 'root', 
@@ -244,7 +250,7 @@ function pathFromURL(url) {
         }
     }
     
-    ['file://','ms-appdata:///','cdvfile://localhost/'].every(function(p) {
+    ['file://','ms-appdata:///','ms-appx://','cdvfile://localhost/'].every(function(p) {
         if (path.indexOf(p)!==0)
             return true;
         var thirdSlash = path.indexOf("/", p.length);


### PR DESCRIPTION
<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist
is intended as a quick reference, for complete details please see our Contributor Guidelines:

http://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->
### Platforms affected

windows
### What does this PR do?

add support to reading files from application directory
### What testing has been done on this change?

without testing
### Checklist
- [+] [ICLA](http://www.apache.org/licenses/icla.txt) has been signed and submitted to secretary@apache.org.
- [+] [Reported an issue](http://cordova.apache.org/contribute/issues.html) in the JIRA database
- [+] Commit message follows the format: "CB-3232: (android) Fix bug with resolving file paths", where CB-xxxx is the JIRA ID & "android" is the platform affected.
- [+] Added automated test coverage as appropriate for this change.
