### PR TITLE
CB-11848 windows: Remove duplicate slash after file system path

### DIFF
--- a/src/windows/FileProxy.js
+++ b/src/windows/FileProxy.js
@@ -154,8 +154,13 @@ var WinFS = function(name, root) {
     if (this.winpath && !/\/$/.test(this.winpath)) {
         this.winpath += "/";
     }
-    this.makeNativeURL = function(path) {
-        return FileSystem.encodeURIPath(this.root.nativeURL + sanitize(path.replace(':','%3A')));};
+    this.makeNativeURL = function (path) {        
+        //CB-11848: This RE supposed to match all leading slashes in sanitized path. 
+        //Removing leading slash to avoid duplicating because this.root.nativeURL already has trailing slash
+        var regLeadingSlashes = /^\/*/;
+        var sanitizedPath = sanitize(path.replace(':', '%3A')).replace(regLeadingSlashes, '');
+        return FileSystem.encodeURIPath(this.root.nativeURL + sanitizedPath);
+    };
     root.fullPath = '/';
     if (!root.nativeURL)
             root.nativeURL = 'file://'+sanitize(this.winpath + root.fullPath).replace(':','%3A');

--- a/tests/tests.js
+++ b/tests/tests.js
@@ -368,6 +368,20 @@ exports.defineAutoTests = function () {
                     }
                     createDirectory(fileName, gotDirectory, failed.bind(null, done, 'createDirectory - Error creating directory: ' + fileName), failed.bind(null, done, 'createDirectory - Error creating directory: ' + fileName));
                 });
+
+                it("file.spec.9.7 should resolve a file with valid nativeURL", function (done) {
+                    var fileName = "de.create.file",
+                    win = function (entry) {
+                        var path = entry.nativeURL.split('///')[1];
+                        expect(/\/{2,}/.test(path)).toBeFalsy();
+                        // cleanup
+                        deleteEntry(entry.name, done);
+                    };
+                    root.getFile(fileName, {
+                        create: true
+                    }, win, succeed.bind(null, done, 'root.getFile - Error unexpected callback, file should not exists: ' + fileName));
+                });
+
                 it("file.spec.10 resolve valid file name with parameters", function (done) {
                     var fileName = "resolve.file.uri.params",
                     win = function (fileEntry) {


### PR DESCRIPTION
<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist
is intended as a quick reference, for complete details please see our Contributor Guidelines:

http://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->

### Platforms affected
Windows

### What does this PR do?
As we have always trailing slash after file system path we get invalid URI, for example ms-appdata:///temp//myfile.file, therefore we needn't leading slash in path argument. This PR removes it.

### What testing has been done on this change?
Auto test

### Checklist
- [x] [ICLA](http://www.apache.org/licenses/icla.txt) has been signed and submitted to secretary@apache.org.
- [x] [Reported an issue](http://cordova.apache.org/contribute/issues.html) in the JIRA database
- [x] Commit message follows the format: "CB-3232: (android) Fix bug with resolving file paths", where CB-xxxx is the JIRA ID & "android" is the platform affected.
- [x] Added automated test coverage as appropriate for this change.

