### PR TITLE
CB-11947 fixed typo that occurs when adding file-transfer plugin to android

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -109,8 +109,10 @@ xmlns:android="http://schemas.android.com/apk/res/android"
         <runs />
     </js-module>
 
-    <info>
-The Android Persistent storage location now defaults to "Internal". Please check this plugins README to see if you application needs any changes in its config.xml.
+    <!-- android -->
+    <platform name="android">
+        <info>
+The Android Persistent storage location now defaults to "Internal". Please check this plugin's README to see if your application needs any changes in its config.xml.
 
 If this is a new application no changes are required.
 
@@ -119,11 +121,7 @@ If this is an update to an existing application that did not specify an "Android
       "&lt;preference name="AndroidPersistentFileLocation" value="Compatibility" /&gt;"
 
 to config.xml in order for the application to find previously stored files.
-
-    </info>
-
-    <!-- android -->
-    <platform name="android">
+        </info>
         <config-file target="res/xml/config.xml" parent="/*">
             <feature name="File" >
                 <param name="android-package" value="org.apache.cordova.file.FileUtils"/>


### PR DESCRIPTION
<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist
is intended as a quick reference, for complete details please see our Contributor Guidelines:

http://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->

### Platforms affected


### What does this PR do?
CB-11947 fixed typo that occurs when adding file-transfer plugin to android 

### What testing has been done on this change?
Installed cordova-plugin-file for multiple platforms to check

### Checklist
- [X ] [ICLA](http://www.apache.org/licenses/icla.txt) has been signed and submitted to secretary@apache.org.
- [X ] [Reported an issue](http://cordova.apache.org/contribute/issues.html) in the JIRA database
- [X ] Commit message follows the format: "CB-3232: (android) Fix bug with resolving file paths", where CB-xxxx is the JIRA ID & "android" is the platform affected.
- [ ] Added automated test coverage as appropriate for this change.

