### PR TITLE
CB-12112 windows: Make available to move folder trees

### DIFF
--- a/src/windows/FileProxy.js
+++ b/src/windows/FileProxy.js
@@ -404,8 +404,8 @@ function moveFolder(src,dst,name) {
                         src.deleteAsync().done(complete,failed);
                         return;
                     }
-                    moveFolder(the.folders[todo],dst)
-                    .done(movefolders,failed); 
+                    moveFolder(the.folders[todo], the.fld)
+                    .done(movefolders,failed);
                 };
                 var movefiles = function() {
                     if (!(todo--)) {

--- a/tests/tests.js
+++ b/tests/tests.js
@@ -1758,6 +1758,37 @@ exports.defineAutoTests = function () {
                     }, failed.bind(null, done, 'createDirectory - Error creating directory : ' + srcDir));
                 }, failed.bind(null, done, 'deleteEntry - Error removing directory : ' + dstDir));
             });
+
+            it("file.spec.131 moveTo: directories tree to new parent", function (done) {
+                if (isIndexedDBShim) {
+                    /* `copyTo` and `moveTo` functions do not support directories (Firefox, IE) */
+                    pending();
+                }
+
+                var srcDir = "entry.move.dnp.srcDir";
+                var srcDirNestedFirst = "entry.move.dnp.srcDir.Nested1";
+                var srcDirNestedSecond = "entry.move.dnp.srcDir.Nested2";
+                var dstDir = "entry.move.dnp.dstDir";
+
+                createDirectory(dstDir, function (dstDirectory) {
+                    createDirectory(srcDir, function (srcDirectory) {
+                        srcDirectory.getDirectory(srcDirNestedFirst, { create: true }, function () {
+                            srcDirectory.getDirectory(srcDirNestedSecond, { create: true }, function () {
+                                srcDirectory.moveTo(dstDirectory, srcDir, function successMove(transferredDirectory) {
+                                    var directoryReader = transferredDirectory.createReader();
+                                    directoryReader.readEntries(function successRead(entries) {
+                                        expect(entries.length).toBe(2);
+                                        expect(entries[0].name).toBe(srcDirNestedFirst);
+                                        expect(entries[1].name).toBe(srcDirNestedSecond);
+                                        deleteEntry(dstDir, done);
+                                    }, failed.bind(null, done, 'Error getting entries from: ' + transferredDirectory));
+                                }, failed.bind(null, done, 'directory.moveTo - Error moving directory : ' + srcDir + ' to root as: ' + dstDir));
+                            }, failed.bind(null, done, 'directory.getDirectory - Error creating directory : ' + srcDirNestedSecond));
+                        }, failed.bind(null, done, 'directory.getDirectory - Error creating directory : ' + srcDirNestedFirst));
+                    }, failed.bind(null, done, 'createDirectory - Error creating source directory : ' + srcDir));
+                }, failed.bind(null, done, 'createDirectory - Error creating dest directory : ' + dstDir));
+            });
+
             it("file.spec.70 moveTo: directory onto itself", function (done) {
                 if (isIndexedDBShim) {
                     /* `copyTo` and `moveTo` functions do not support directories (Firefox, IE) */


### PR DESCRIPTION
<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist
is intended as a quick reference, for complete details please see our Contributor Guidelines:

http://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->

### Platforms affected
Windows

### What does this PR do?
There was a mistake in the logic of recursive function for moving operation. As for destination folder, it was always used start folder.

### What testing has been done on this change?
Auto-test

### Checklist
- [x] [Reported an issue](http://cordova.apache.org/contribute/issues.html) in the JIRA database
- [x] Commit message follows the format: "CB-3232: (android) Fix bug with resolving file paths", where CB-xxxx is the JIRA ID & "android" is the platform affected.
- [x] Added automated test coverage as appropriate for this change.

