### PR TITLE
CB-12355: (iOS) fix FileEntry.file.type

### DIFF
--- a/src/ios/CDVLocalFilesystem.m
+++ b/src/ios/CDVLocalFilesystem.m
@@ -731,6 +731,7 @@
     callback(result);
 }
 
+// fix errors that base on Alexsander Akers from http://stackoverflow.com/a/5998683/2613194
 - (NSString*) mimeTypeForFileAtPath: (NSString *) path {
     if (![[NSFileManager defaultManager] fileExistsAtPath:path]) {
         return nil;

--- a/src/ios/CDVLocalFilesystem.m
+++ b/src/ios/CDVLocalFilesystem.m
@@ -703,7 +703,7 @@
         NSMutableDictionary* fileInfo = [NSMutableDictionary dictionaryWithCapacity:5];
 
         [fileInfo setObject:localURL.fullPath forKey:@"fullPath"];
-        [fileInfo setObject:@"" forKey:@"type"];  // can't easily get the mimetype unless create URL, send request and read response so skipping
+        [fileInfo setObject:[self mimeTypeForFileAtPath: path] forKey:@"type"];
         [fileInfo setObject:[path lastPathComponent] forKey:@"name"];
 
         // Ensure that directories (and other non-regular files) report size of 0
@@ -729,6 +729,21 @@
     }
 
     callback(result);
+}
+
+- (NSString*) mimeTypeForFileAtPath: (NSString *) path {
+    if (![[NSFileManager defaultManager] fileExistsAtPath:path]) {
+        return nil;
+    }
+    
+    CFStringRef UTI = UTTypeCreatePreferredIdentifierForTag(kUTTagClassFilenameExtension, (__bridge CFStringRef)[path pathExtension], NULL);
+    CFStringRef mimeType = UTTypeCopyPreferredTagWithClass (UTI, kUTTagClassMIMEType);
+    CFRelease(UTI);
+    
+    if (!mimeType) {
+        return @"application/octet-stream";
+    }
+    return (__bridge NSString *)mimeType;
 }
 
 @end


### PR DESCRIPTION
### Platforms affected
iOS

### What does this PR do?
fix iOS FileEntry.file callback return a null type

### What testing has been done on this change?
install to project and install on real device (iPhone 5, 6, 6s) and simulator

### Checklist
- [x] [Reported an issue](http://cordova.apache.org/contribute/issues.html) in the JIRA database
- [x] Commit message follows the format: "CB-3232: (android) Fix bug with resolving file paths", where CB-xxxx is the JIRA ID & "android" is the platform affected.
- [x] Added automated test coverage as appropriate for this change.
