### PR TITLE
Method GetFreeDiskSpace. Consistency Android and IOS

### DIFF
--- a/src/android/DirectoryManager.java
+++ b/src/android/DirectoryManager.java
@@ -58,7 +58,7 @@ public class DirectoryManager {
     /**
      * Get the free space in external storage
      *
-     * @return 		Size in KB or -1 if not available
+     * @return 		Size in Bytes or -1 if not available
      */
     public static long getFreeExternalStorageSpace() {
         String status = Environment.getExternalStorageState();
@@ -72,7 +72,7 @@ public class DirectoryManager {
             return -1;
         }
 
-        return freeSpaceInBytes / 1024;
+        return freeSpaceInBytes;
     }
 
     /**


### PR DESCRIPTION
<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist
is intended as a quick reference, for complete details please see our Contributor Guidelines:

http://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->

### Platforms affected

Android

### What does this PR do?

Adding consistency with IOS method which return bytes and Android return KB. Now both method return the same unit of measurement (bytes)


### What testing has been done on this change?

N/A


### Checklist
- [ ] [Reported an issue](http://cordova.apache.org/contribute/issues.html) in the JIRA database
- [ ] Commit message follows the format: "CB-3232: (android) Fix bug with resolving file paths", where CB-xxxx is the JIRA ID & "android" is the platform affected.
- [ ] Added automated test coverage as appropriate for this change.
