### PR TITLE
CB-12930: (windows) Fix getDirectory trailing slash path

### DIFF
--- a/src/windows/FileProxy.js
+++ b/src/windows/FileProxy.js
@@ -751,7 +751,13 @@ module.exports = {
         if (!fs || !validName(path)){
             fail(FileError.ENCODING_ERR);
             return;
-        }           
+        }
+	    
+        //check trailing "/"
+        if (path.length > 1 && path[path.length - 1] === "/") {
+            path = path.substring(0, path.length - 1);
+        }
+	    
         var fspath = sanitize(dirpath +'/'+ path);
         var completePath = sanitize(fs.winpath + fspath);
 


### PR DESCRIPTION
<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist
is intended as a quick reference, for complete details please see our Contributor Guidelines:

http://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->

### Platforms affected
Windows


### What does this PR do?
Fix the issue

### What testing has been done on this change?
Test on WP 8.1/10 and Desktop Win10

### Checklist
- [x] [Reported an issue](http://cordova.apache.org/contribute/issues.html) in the JIRA database
- [x] Commit message follows the format: "CB-3232: (android) Fix bug with resolving file paths", where CB-xxxx is the JIRA ID & "android" is the platform affected.
- [ ] Added automated test coverage as appropriate for this change.
