### PR TITLE
fix(ios): copyTo should overwrite any existing file (CB-6938)

### DIFF
--- a/src/ios/CDVLocalFilesystem.m
+++ b/src/ios/CDVLocalFilesystem.m
@@ -551,8 +551,13 @@
                     // can't copy dir into self
                     errCode = INVALID_MODIFICATION_ERR;
                 } else if (bNewExists) {
-                    // the full destination should NOT already exist if a copy
-                    errCode = PATH_EXISTS_ERR;
+                    // first try to remove the existing file
+                    bSuccess = [fileMgr removeItemAtPath:newFileSystemPath error:&error];
+
+                    if (bSuccess) {
+                        // then copy the new one
+                        bSuccess = [fileMgr copyItemAtPath:srcFullPath toPath:newFileSystemPath error:&error];
+                    }
                 } else {
                     bSuccess = [fileMgr copyItemAtPath:srcFullPath toPath:newFileSystemPath error:&error];
                 }


### PR DESCRIPTION
https://issues.apache.org/jira/browse/CB-6938

### Platforms affected
iOS, all versions.

### What does this PR do?
It fixes CB-6938.
Instead of returning an error 12 (PATH_EXISTS_ERR), it tries to remove the existing file, then to copy the "new" one.

### What testing has been done on this change?
Simulator: iPhone 5 and iPhone 6 @ iOS 9, 10.
Real device: iPhone 5 @ iOS 10.

No unit test provided nor written.

### Checklist
- [X] [Reported an issue](http://cordova.apache.org/contribute/issues.html) in the JIRA database
- [ ] Commit message follows the format: "CB-3232: (android) Fix bug with resolving file paths", where CB-xxxx is the JIRA ID & "android" is the platform affected.
- [ ] Added automated test coverage as appropriate for this change.
