### PR TITLE
Add mandatory iOS 10 privacy description

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -247,6 +247,11 @@ to config.xml in order for the application to find previously stored files.
 
         <framework src="AssetsLibrary.framework" />
         <framework src="MobileCoreServices.framework" />
+
+        <preference name="PHOTOLIBRARY_USAGE_DESCRIPTION" default=" "/>
+        <config-file target="*-Info.plist" parent="NSPhotoLibraryUsageDescription">
+            <string>$PHOTOLIBRARY_USAGE_DESCRIPTION</string>
+        </config-file>
     </platform>
 
     <!-- osx -->


### PR DESCRIPTION
<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist
is intended as a quick reference, for complete details please see our Contributor Guidelines:

http://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->

### Platforms affected
iOS

### What does this PR do?
Ensures the plugin enables users to select photos from the photoalbum in iOS10.

### What testing has been done on this change?
It was a bug in my app before, and after this change, I am now able to successfully select photos from the photoalbum

### Checklist
- [ ] [Reported an issue](http://cordova.apache.org/contribute/issues.html) in the JIRA database
- [ ] Commit message follows the format: "CB-3232: (android) Fix bug with resolving file paths", where CB-xxxx is the JIRA ID & "android" is the platform affected.
- [ ] Added automated test coverage as appropriate for this change.
