### PR TITLE
fix(android): Fix bug caused by negative length reported for an asset (CB-13245)

### DIFF
--- a/src/android/Filesystem.java
+++ b/src/android/Filesystem.java
@@ -269,8 +269,11 @@ public abstract class Filesystem {
     public void readFileAtURL(LocalFilesystemURL inputURL, long start, long end,
                               ReadFileCallback readFileCallback) throws IOException {
         CordovaResourceApi.OpenForReadResult ofrr = resourceApi.openForRead(toNativeUri(inputURL));
+        long length = ofrr.length;
+        if (length < 0)
+            length = ofrr.inputStream.available();
         if (end < 0) {
-            end = ofrr.length;
+            end = length;
         }
         long numBytesToRead = end - start;
         try {
@@ -278,7 +281,7 @@ public abstract class Filesystem {
                 ofrr.inputStream.skip(start);
             }
             InputStream inputStream = ofrr.inputStream;
-            if (end < ofrr.length) {
+            if (end < length) {
                 inputStream = new LimitedInputStream(inputStream, numBytesToRead);
             }
             readFileCallback.handleData(inputStream, ofrr.mimeType);


### PR DESCRIPTION
<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist
is intended as a quick reference, for complete details please see our Contributor Guidelines:

http://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->

### Platforms affected
Android

### What does this PR do?
Check the length of CordovaResourceApi.OpenForReadResult in readFileAtURL() to fix loading Android assets with a length greater than FileReader.READ_CHUNK_SIZE. When the length returned is < 0, use InputStream.available() to get the length of compressed assets.

### What testing has been done on this change?
Fixes a bug in one of my apps when loading a large .json file into a string.

### Checklist
- [X] [Reported an issue](http://cordova.apache.org/contribute/issues.html) in the JIRA database
- [X] Commit message follows the format: "CB-3232: (android) Fix bug with resolving file paths", where CB-xxxx is the JIRA ID & "android" is the platform affected.
- [ ] Added automated test coverage as appropriate for this change.
