### PR TITLE
fixing README: use of resolveLocalFileSystemURL command

### DIFF
--- a/README.md
+++ b/README.md
@@ -571,7 +571,7 @@ The File plugin allows you to do things like store files in a temporary or persi
 
 Before you use the File plugin APIs, you can get access to the file system using `requestFileSystem`. When you do this, you can request either persistent or temporary storage. Persistent storage will not be removed unless permission is granted by the user.
 
-When you get file system access using `requestFileSystem`, access is granted for the sandboxed file system only (the sandbox limits access to the app itself), not for general access to any file system location on the device. (To access file system locations outside the sandboxed storage, use other methods such as window.requestLocalFileSystemURL, which support platform-specific locations. For one example of this, see _Append a File_.)
+When you get file system access using `requestFileSystem`, access is granted for the sandboxed file system only (the sandbox limits access to the app itself), not for general access to any file system location on the device. (To access file system locations outside the sandboxed storage, use other methods such as window.resolveLocalFileSystemURL, which support platform-specific locations. For one example of this, see _Append a File_.)
 
 Here is a request for persistent storage.
 


### PR DESCRIPTION
### What does this PR do?

fixes `README.md` in use of `window.resolveLocalFileSystemURL` instead of non-existent `window.requestLocalFileSystemURL`