### PR TITLE
CB-13481: (android) Don't ask for permission to read file:///android_asset/

### DIFF
--- a/src/android/FileUtils.java
+++ b/src/android/FileUtils.java
@@ -570,6 +570,7 @@ public class FileUtils extends CordovaPlugin {
     private boolean needPermission(String nativeURL, int permissionType) throws JSONException {
         JSONObject j = requestAllPaths();
         ArrayList<String> allowedStorageDirectories = new ArrayList<String>();
+        allowedStorageDirectories.add(j.getString("applicationDirectory"));
         allowedStorageDirectories.add(j.getString("applicationStorageDirectory"));
         if(j.has("externalApplicationStorageDirectory")) {
             allowedStorageDirectories.add(j.getString("externalApplicationStorageDirectory"));


### PR DESCRIPTION
### Platforms affected
Android 6+

### What does this PR do?
Allow reading from `cordova.file.applicationDirectory` (`file:///android_asset/`) without asking the user for permission.

### What testing has been done on this change?
Modified the code and ran it on an Android 6.0 device (See sample code in the JIRA bug).

### Checklist
- [x] [Reported an issue](http://cordova.apache.org/contribute/issues.html) in the JIRA database
- [x] Commit message follows the format: "CB-3232: (android) Fix bug with resolving file paths", where CB-xxxx is the JIRA ID & "android" is the platform affected.
- [ ] Added automated test coverage as appropriate for this change.
