### PR TITLE
CB-13850: Fix spelling in typed-file: property name filesystem (wrong…

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -63,7 +63,7 @@ interface Entry {
     /** The full absolute path from the root to the entry. */
     fullPath: string;
     /** The file system on which the entry resides. */
-    fileSystem: FileSystem;
+    filesystem: FileSystem;
     nativeURL: string;
     /**
      * Look up metadata about this entry.


### PR DESCRIPTION
<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist
is intended as a quick reference, for complete details please see our Contributor Guidelines:

http://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->

### Platforms affected
-

### What does this PR do?
The DefinitelyTyped file has a wrong attribute for an Entry object. It is "fileSystem" but should be "filesystem". The consequence of this is that the syntax checker of an IDE might give an false warning.

### What testing has been done on this change?
Looked at file www/Entry.js. Obviously the naming is here "filesystem".

### Checklist
- [ x ] [Reported an issue](http://cordova.apache.org/contribute/issues.html) in the JIRA database
- [ x ] Commit message follows the format: "CB-3232: (android) Fix bug with resolving file paths", where CB-xxxx is the JIRA ID & "android" is the platform affected.
- Automated tests are not possible, because this bug is related to a DefinitelyTyped file, which provides only syntax checking for IDEs.
