### PR TITLE
fix(android): getDirectory("") returns current path instead of / path (CB-13849)

### DIFF
--- a/src/android/AssetFilesystem.java
+++ b/src/android/AssetFilesystem.java
@@ -215,7 +215,7 @@ public class AssetFilesystem extends Filesystem {
         }
 
         // Check whether the supplied path is absolute or relative
-        if (directory && !path.endsWith("/")) {
+        if (directory && !path.endsWith("/") && !"".equals(path)) {
             path += "/";
         }
 

--- a/src/android/LocalFilesystem.java
+++ b/src/android/LocalFilesystem.java
@@ -128,7 +128,7 @@ public class LocalFilesystem extends Filesystem {
         LocalFilesystemURL requestedURL;
 
         // Check whether the supplied path is absolute or relative
-        if (directory && !path.endsWith("/")) {
+        if (directory && !path.endsWith("/") && !"".equals(path)) {
             path += "/";
         }
         if (path.startsWith("/")) {


### PR DESCRIPTION
<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist
is intended as a quick reference, for complete details please see our Contributor Guidelines:

http://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->

### Platforms affected
- Android


### What does this PR do?
Currently the comman getDirectory('') with an empty parameter returns always the root path. It does not matter on which path this command is executed. This is an unexpected behaviour and might cause security issues.
With this patch the path of the current directory is returned, like in other implementations (i.e. browser).

### What testing has been done on this change?
It has been tested on an emulator. Furthermore the sourcecode has been evaluated and there is no negative issues with it. 

### Checklist
- [x] [Reported an issue](http://cordova.apache.org/contribute/issues.html) in the JIRA database
- [x] Commit message follows the format: "CB-3232: (android) Fix bug with resolving file paths", where CB-xxxx is the JIRA ID & "android" is the platform affected.
- [ ] Added automated test coverage as appropriate for this change.
