### PR TITLE
CB-13960: fix FileWriter.write argument type definition for typescript

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -294,9 +294,9 @@ interface FileWriter extends FileSaver {
     length: number;
     /**
      * Write the supplied data to the file at position.
-     * @param {Blob} data The blob to write.
+     * @param {Blob|string} data The blob to write.
      */
-    write(data: Blob): void;
+    write(data: Blob|string): void;
     /**
      * The file position at which the next write will occur.
      * @param offset If nonnegative, an absolute byte offset into the file.


### PR DESCRIPTION
Fix FileWriter.write argument type definition for typescript
