### PR TITLE
fix(browser): Error on browser platform

### DIFF
--- a/www/resolveLocalFileSystemURI.js
+++ b/www/resolveLocalFileSystemURI.js
@@ -54,7 +54,7 @@
         };
         // sanity check for 'not:valid:filename' or '/not:valid:filename'
         // file.spec.12 window.resolveLocalFileSystemURI should error (ENCODING_ERR) when resolving invalid URI with leading /.
-        if (!uri || uri.split(':').length > 2) {
+        if (!uri || uri.split(':').length > 3) {
             setTimeout(function () {
                 fail(FileError.ENCODING_ERR);
             }, 0);


### PR DESCRIPTION
If you try to use this while running `cordova run browser`, this line will always fail because URI starts with 'http://localhost:8000/'. Changing it to 3 fixes this issue, but I'm unclear if there are unintended consequences. I'm not familiar enough with the code base to fully test etc, but hopefully someone with more knowledge can easily tell. 