### PR TITLE
CB-14181: (android) Fix bug - Cannot read property 'filesystemName' of null

### DIFF
--- a/www/fileSystems-roots.js
+++ b/www/fileSystems-roots.js
@@ -30,8 +30,10 @@ require('./fileSystems').getFs = function (name, callback) {
         fsMap = {};
         for (var i = 0; i < response.length; ++i) {
             var fsRoot = response[i];
-            var fs = new FileSystem(fsRoot.filesystemName, fsRoot);
-            fsMap[fs.name] = fs;
+            if (fsRoot) {
+                var fs = new FileSystem(fsRoot.filesystemName, fsRoot);
+                fsMap[fs.name] = fs;                    
+            }
         }
         callback(fsMap[name]);
     }

--- a/www/fileSystems-roots.js
+++ b/www/fileSystems-roots.js
@@ -32,7 +32,7 @@ require('./fileSystems').getFs = function (name, callback) {
             var fsRoot = response[i];
             if (fsRoot) {
                 var fs = new FileSystem(fsRoot.filesystemName, fsRoot);
-                fsMap[fs.name] = fs;                    
+                fsMap[fs.name] = fs;
             }
         }
         callback(fsMap[name]);


### PR DESCRIPTION
fix error :

Error in Success callbackId: File1539060614 : TypeError: Cannot read property 'filesystemName' of null
cordova.js:314 Uncaught TypeError: Cannot read property 'filesystemName' of null

The `fsRoot` might be null. reproduced with latest cordova on android emulator.

<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist
is intended as a quick reference, for complete details please see our Contributor Guidelines:

http://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->

### Platforms affected


### What does this PR do?


### What testing has been done on this change?


### Checklist
- [x] [Reported an issue](http://cordova.apache.org/contribute/issues.html) in the JIRA database
- [x] Commit message follows the format: "CB-3232: (android) Fix bug with resolving file paths", where CB-xxxx is the JIRA ID & "android" is the platform affected. 
https://issues.apache.org/jira/browse/CB-14181
- [ ] Added automated test coverage as appropriate for this change.
