### PR TITLE
fix(android): Use cdvPluginPostBuildExtras instead of ext.postBuildExtras (CB-14163)

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -162,6 +162,7 @@ to config.xml in order for the application to find previously stored files.
             <merges target="cordova" />
             <runs/>
         </js-module>
+        <framework src="src/android/build-extras.gradle" custom="true" type="gradleReference" />
     </platform>
 
     <!-- ios -->

--- a/src/android/build-extras.gradle
+++ b/src/android/build-extras.gradle
@@ -16,7 +16,7 @@
        specific language governing permissions and limitations
        under the License.
  */
-ext.postBuildExtras = {
+cdvPluginPostBuildExtras.add({
     def inAssetsDir = file("assets")
     def outAssetsDir = inAssetsDir
     def outFile = new File(outAssetsDir, "cdvasset.manifest")
@@ -44,4 +44,4 @@ ext.postBuildExtras = {
     newTask.outputs.file outFile
     def preBuildTask = tasks["preBuild"]
     preBuildTask.dependsOn(newTask)
-}
+})


### PR DESCRIPTION
# Use cdvPluginPostBuildExtras instead of ext.postBuildExtras

### Platforms affected
Android

### What does this PR do?
1. Adds a reference to the `build-extras.gradle` file in `plugin.xml` so that the code in `build-extras.gradle` will run with the main Cordova `build.gradle`.
2. Replaces incorrect usage of `ext.postBuildExtras` with usage of `cdvPluginPostBuildExtras`.

### What testing has been done on this change?
Added the modified cordova-plugin-file to a Cordova project and verified that the code in `build-extras.gradle` ran during the execution of the command `cordova build android`.

### Checklist
- [x] [Reported an issue](http://cordova.apache.org/contribute/issues.html) in the JIRA database
- [x] Commit message follows the format: "CB-3232: (android) Fix bug with resolving file paths", where CB-xxxx is the JIRA ID & "android" is the platform affected.
- [ ] Added automated test coverage as appropriate for this change.
