### PR TITLE
CB-14197: (all) Fix for createFile/writeFile silently failing to send 'write' action

### DIFF
--- a/www/FileWriter.js
+++ b/www/FileWriter.js
@@ -21,6 +21,7 @@
 
 var exec = require('cordova/exec');
 var FileError = require('./FileError');
+var FileReader = require('./FileReader');
 var ProgressEvent = require('./ProgressEvent');
 
 /**


### PR DESCRIPTION
FileWriter is missing the require('./FileReader') module causing the
native FileReader to be used instead of the FileReader proxy.

Oddly this does not happen everytime, but I could consistently
reproduce the issue when running subsequent `cordova run android`
commands on an Ionic app running in a 7.1.1 Android Emulator.

### Platforms affected
All Platforms
Witnessed on Android

### What does this PR do?
Adds a missing require statement to ensure the correct FileReader is used

### What testing has been done on this change?
Since this issue was very difficult to reproduce it was pretty hard to test. We found
that this issue occurs most frequently when running our ionic app in the Android
emulator and then run `ionic cordova run android` multiple times to reinstall the app
before we consistently saw the issue. With the changes from this PR we stopped
seeing the issue entirely.

I believe this PR will also fix the issue reported on the ionic-native project:
https://github.com/ionic-team/ionic-native/issues/2067

`npm test` passes

### Checklist
- [x] [Reported an issue](http://cordova.apache.org/contribute/issues.html) in the JIRA database
- [x] Commit message follows the format: "CB-3232: (android) Fix bug with resolving file paths", where CB-xxxx is the JIRA ID & "android" is the platform affected.
- [ ] Added automated test coverage as appropriate for this change.
