### PR TITLE
fix(android, ios, windows) Handle multi-byte UTF-8 characters that cross a chunk boundary (CB-13570)

### DIFF
--- a/src/android/FileUtils.java
+++ b/src/android/FileUtils.java
@@ -59,10 +59,10 @@ import java.util.HashSet;
 public class FileUtils extends CordovaPlugin {
     private static final String LOG_TAG = "FileUtils";
 
-    private static final String READ_RESULT_TYPE_TEXT = "TEXT";
-    private static final String READ_RESULT_TYPE_ARRAYBUFFER = "ARRAYBUFFER";
-    private static final String READ_RESULT_TYPE_BINARYSTRING = "BINARYSTRING";
-    private static final String READ_RESULT_TYPE_DATAURL = "DATAURL";
+    private static final int READ_RESULT_TYPE_TEXT = 0;
+    private static final int READ_RESULT_TYPE_ARRAYBUFFER = 10;
+    private static final int READ_RESULT_TYPE_BINARYSTRING = 20;
+    private static final int READ_RESULT_TYPE_DATAURL = 30;
 
     // Using hard-coded encoding names vs java.nio.StandardCharsets for a lower min SDK version.
     // java.nio.StandardCharsets requires Android SDK 19+.
@@ -1068,7 +1068,7 @@ public class FileUtils extends CordovaPlugin {
      * @param resultType        The desired type of data to send to the callback.
      * @return                  Contents of file.
      */
-    public void readFileAs(final String srcURLstr, final int start, final int end, final CallbackContext callbackContext, final String encoding, final String resultType) throws MalformedURLException {
+    public void readFileAs(final String srcURLstr, final int start, final int end, final CallbackContext callbackContext, final String encoding, final int resultType) throws MalformedURLException {
         try {
         	LocalFilesystemURL inputURL = LocalFilesystemURL.parse(srcURLstr);
         	Filesystem fs = this.filesystemForURL(inputURL);
@@ -1076,13 +1076,13 @@ public class FileUtils extends CordovaPlugin {
         		throw new MalformedURLException("No installed handlers for this URL");
         	}
 
-            Charset charset = READ_RESULT_TYPE_TEXT.equals(resultType) ? lookupCharset(encoding) : null;
+            final Charset charset = READ_RESULT_TYPE_TEXT == resultType ? lookupCharset(encoding) : null;
             // Canonical encoding name to abstract away insignificant differences in the passed encoding, e.g. UTF-8 vs utf8 vs utf-8
-            String canonicalEncoding = charset == null ? null : charset.name();
+            final String canonicalEncoding = charset == null ? null : charset.name();
 
             // For text reads, have to handle chunking and variable-length encoding (e.g. UTF-8)
             // Handle the start offset strictly, but extend the end offset as needed to prevent splitting multi-byte characters.
-            int extendedEnd = READ_RESULT_TYPE_TEXT.equals(resultType) && end > 0 && end > start ?
+            int extendedEnd = READ_RESULT_TYPE_TEXT == resultType && end > 0 && end > start ?
                 extendTextSelectionEnd(end, canonicalEncoding) : end;
             // NOTE: extendedEnd could extend past the end of the file.
             // We're relying on our Filesystem class to be able to handle that.

--- a/src/ios/CDVFile.m
+++ b/src/ios/CDVFile.m
@@ -923,7 +923,7 @@ NSString* const kCDVFilesystemURLPrefix = @"cdvfile";
         uint8_t *lastCharStart = start + desired - 1;
         // Continue looping so long as:
         //   - We don't extend past beginning of buffer
-        //   - We don't examine more than 4 bytes, since valid UTF-8 characters are never more than 4 bytes
+        //   - We don't examine more than 3 bytes, since valid UTF-8 characters are never more than 4 bytes
         //   - We don't find the start of a character. In UTF-8, a byte begins a character iff it has a binary prefix other than 10.
         // For UTF-8 spec, see https://www.unicode.org/versions/Unicode11.0.0/ch03.pdf (search "Table 3-6. UTF-8 Bit Distribution")
         while (lastCharStart > start && lastCharStart > start + desired - 4 && (*lastCharStart & 0xc0) == 0x80) {
@@ -939,8 +939,11 @@ NSString* const kCDVFilesystemURLPrefix = @"cdvfile";
             // Byte has prefix of 11110 -> 4 byte char
             desired = lastCharStart - start + 4;
         }
-        // Anything else: either a single byte char or this must be invalid UTF-8.
-        // Either way, leave desired length unchanged.
+        // Anything else: Possibilities are
+        //   - Single-byte char, OR,
+        //   - Last 3 bytes of a 4-byte char, OR
+        //   - Invalid UTF-8
+        // In all those case, we'll leave the desired length unchanged.
 
         // Once again, need to make sure we don't read past end of buffer
         return desired > [data length] ? [data length] : desired;

--- a/src/ios/CDVFile.m
+++ b/src/ios/CDVFile.m
@@ -17,6 +17,7 @@
  under the License.
  */
 
+#import <stdint.h>
 #import <Cordova/CDV.h>
 #import "CDVFile.h"
 #import "CDVLocalFilesystem.h"
@@ -860,13 +861,23 @@ NSString* const kCDVFilesystemURLPrefix = @"cdvfile";
     __weak CDVFile* weakSelf = self;
 
     [self.commandDelegate runInBackground:^ {
-        [fs readFileAtURL:localURI start:start end:end callback:^(NSData* data, NSString* mimeType, CDVFileError errorCode) {
+        // Handle chunking and variable-length encoding (e.g. UTF-8).
+        // Handle the start offset strictly, but extend the end offset as needed to prevent splitting multi-byte characters.
+        NSInteger extendedEnd = end > 0 && end > start ? [self extendTextSelectionEnd:end encoding:encoding] : end;
+        // NOTE: extendedEnd could extend past the end of the file.
+        // We're relying on our CDVFileSystem impls to be able to handle that.
+        [fs readFileAtURL:localURI start:start end:extendedEnd callback:^(NSData* data, NSString* mimeType, CDVFileError errorCode) {
             CDVPluginResult* result = nil;
             if (data != nil) {
-                NSString* str = [[NSString alloc] initWithBytesNoCopy:(void*)[data bytes] length:[data length] encoding:NSUTF8StringEncoding freeWhenDone:NO];
+                NSUInteger length = end > 0 && end > start ? [self numBytesToDecodeOfData:data desired:(end - start) encoding:encoding] : [data length];
+                NSString* str = [[NSString alloc] initWithBytesNoCopy:(void*)[data bytes] length:length encoding:NSUTF8StringEncoding freeWhenDone:NO];
                 // Check that UTF8 conversion did not fail.
                 if (str != nil) {
-                    result = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK messageAsString:str];
+                    NSDictionary *msg = @{
+                                          @"value": str,
+                                          @"numBytesConsumed": [NSNumber numberWithUnsignedInteger:length]
+                                          };
+                    result = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK messageAsDictionary:msg];
                     result.associatedObject = data;
                 } else {
                     errorCode = ENCODING_ERR;
@@ -879,6 +890,63 @@ NSString* const kCDVFilesystemURLPrefix = @"cdvfile";
             [weakSelf.commandDelegate sendPluginResult:result callbackId:command.callbackId];
         }];
     }];
+}
+
+// Extend the end offset passed to readFileAtURL to accomodate multi-byte characters when chunking.
+// This determines how many extra bytes to read. We'll determine how many of these bytes to actually decode below.
+- (NSInteger)extendTextSelectionEnd:(NSInteger)end encoding:(NSString*)encoding
+{
+    if ([@"UTF-8" caseInsensitiveCompare:encoding] == NSOrderedSame) {
+        // All valid UTF-8 chars are 4 bytes or less, so never have to look ahead more than 3 chars to find a
+        // character boundary.
+        return end + 3;
+    } else {
+        // Fallback to leaving specified range unchanged.
+        return end;
+    }
+}
+
+// Given data, which may be longer than the desired length, a desired byte length, and an encoding,
+// determine how many bytes to decode, making sure the decoded chunk ends at a character boundary.
+- (NSUInteger)numBytesToDecodeOfData:(NSData*)data desired:(NSUInteger)desired encoding:(NSString*)encoding
+{
+    if (desired > [data length]) {
+        // Never extend past end of buffer
+        return [data length];
+    } else if (desired == 0) {
+        // Don't try to extend if desired length is 0 (no way characters could be split)
+        return desired;
+    } else if ([@"UTF-8" caseInsensitiveCompare:encoding] == NSOrderedSame) {
+        uint8_t *start = (uint8_t*)[data bytes];
+        // The last byte within the desired length that represents the start of a character.
+        // Start with the last byte in the desired range, then move backwards until we find a character boundary.
+        uint8_t *lastCharStart = start + desired - 1;
+        // Continue looping so long as:
+        //   - We don't extend past beginning of buffer
+        //   - We don't examine more than 4 bytes, since valid UTF-8 characters are never more than 4 bytes
+        //   - We don't find the start of a character. In UTF-8, a byte begins a character iff it has a binary prefix other than 10.
+        // For UTF-8 spec, see https://www.unicode.org/versions/Unicode11.0.0/ch03.pdf (search "Table 3-6. UTF-8 Bit Distribution")
+        while (lastCharStart > start && lastCharStart > start + desired - 4 && (*lastCharStart & 0xc0) == 0x80) {
+            lastCharStart -= 1;
+        }
+        if ((*lastCharStart & 0xe0) == 0xc0) {
+            // Byte has prefix of 110 -> 2 byte char
+            desired = lastCharStart - start + 2;
+        } else if ((*lastCharStart & 0xf0) == 0xe0) {
+            // Byte has prefix of 1110 -> 3 byte char
+            desired = lastCharStart - start + 3;
+        } else if ((*lastCharStart & 0xf8) == 0xf0) {
+            // Byte has prefix of 11110 -> 4 byte char
+            desired = lastCharStart - start + 4;
+        }
+        // Anything else: either a single byte char or this must be invalid UTF-8.
+        // Either way, leave desired length unchanged.
+
+        // Once again, need to make sure we don't read past end of buffer
+        return desired > [data length] ? [data length] : desired;
+    } else {
+        return desired;
+    }
 }
 
 /* Read content of text file and return as base64 encoded data url.

--- a/src/windows/FileProxy.js
+++ b/src/windows/FileProxy.js
@@ -531,8 +531,11 @@ function extendEndPosForEncoding (stream, endPos, encoding) {
                 // Byte has prefix of 11110 -> 4 byte char
                 endPos = startOfPeek + lastCharStart + 4;
             }
-            // Anything else: either a single byte char or this must be invalid UTF-8.
-            // Either way, leave original endPos unchanged.
+            // Anything else: Possibilities are
+            //   - Single-byte char, OR,
+            //   - Last 3 bytes of a 4-byte char, OR
+            //   - Invalid UTF-8
+            // In all those case, we'll leave the original endPos unchanged.
 
             // Make sure new endPos doesn't go past end of stream.
             return Math.min(endPos, stream.size);

--- a/tests/tests.js
+++ b/tests/tests.js
@@ -2506,8 +2506,8 @@ exports.defineAutoTests = function () {
                 }, undefined, undefined, JSON.stringify(testObject));
             });
             it('file.spec.84.2 should read multi-byte UTF-8 chars across chunk boundaries', function (done) {
-                var oldChunkSize = FileReader.READ_CHUNK_SIZE;
-                FileReader.READ_CHUNK_SIZE = 4;
+                var oldChunkSize = FileReader.READ_CHUNK_SIZE; // eslint-disable-line no-undef
+                FileReader.READ_CHUNK_SIZE = 4; // eslint-disable-line no-undef
                 // \u0080    -- 2 bytes in UTF-8
                 // \u0800    -- 3 bytes in UTF-8
                 // \u{10000} -- 4 bytes in UTF-8
@@ -2516,7 +2516,7 @@ exports.defineAutoTests = function () {
                 // ways across a chunk boundary.
                 var text = '---\u0080---\u0800--\u0800---\u{10000}--\u{10000}-\u{10000}';
                 var doneAndReset = function () {
-                    FileReader.READ_CHUNK_SIZE = oldChunkSize;
+                    FileReader.READ_CHUNK_SIZE = oldChunkSize; // eslint-disable-line no-undef
                     done();
                 };
                 runReaderTest('readAsText', false, doneAndReset, null, function (evt) {

--- a/www/FileReader.js
+++ b/www/FileReader.js
@@ -137,8 +137,9 @@ function readSuccessCallback (readType, encoding, offset, totalSize, accumulate,
         //   2) Just the read value, in which case we assume numBytesConsumed matches the CHUNK_SIZE.
         // Option 1 gives the native read methods flexibility to read more or fewer bytes as appropriate, e.g. to
         // accomodate variable length encodings with readAsText.
-        var value = r && typeof r === 'object' && 'value' in r ? r.value : r;
-        var numBytesConsumed = r && typeof r === 'object' && 'numBytesConsumed' in r ? r.numBytesConsumed : CHUNK_SIZE;
+        var hasResultsObj = r && typeof r === 'object' && !(r instanceof ArrayBuffer); // ArrayBuffer also reports typeof as 'object'
+        var value = hasResultsObj && 'value' in r ? r.value : r;
+        var numBytesConsumed = hasResultsObj && 'numBytesConsumed' in r ? r.numBytesConsumed : CHUNK_SIZE;
         accumulate(value);
         this._progress = Math.min(this._progress + numBytesConsumed, totalSize);
 

--- a/www/FileReader.js
+++ b/www/FileReader.js
@@ -132,8 +132,15 @@ function readSuccessCallback (readType, encoding, offset, totalSize, accumulate,
     }
 
     if (typeof r !== 'undefined') {
-        accumulate(r);
-        this._progress = Math.min(this._progress + CHUNK_SIZE, totalSize);
+        // The native read methods can return either:
+        //   1) An object with properties 'value' and 'numBytesConsumed', or
+        //   2) Just the read value, in which case we assume numBytesConsumed matches the CHUNK_SIZE.
+        // Option 1 gives the native read methods flexibility to read more or fewer bytes as appropriate, e.g. to
+        // accomodate variable length encodings with readAsText.
+        var value = r && typeof r === 'object' && 'value' in r ? r.value : r;
+        var numBytesConsumed = r && typeof r === 'object' && 'numBytesConsumed' in r ? r.numBytesConsumed : CHUNK_SIZE;
+        accumulate(value);
+        this._progress = Math.min(this._progress + numBytesConsumed, totalSize);
 
         if (typeof this.onprogress === 'function') {
             this.onprogress(new ProgressEvent('progress', {loaded: this._progress, total: totalSize}));


### PR DESCRIPTION
<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist
is intended as a quick reference, for complete details please see our Contributor Guidelines:

http://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->

### Platforms affected
Android, iOS, Windows.

My organization hit this one in production in a highly visible (to the end user) setting. So I've gone ahead and fixed the 3 platforms we target. I haven't yet tested on OSX or browser, but looking at the source it looks like fixes are likely needed on those platforms too. I don't think that needs to hold up this PR, b/c I've made my change in a backwards compatible way. But that could be an area to discuss.

### What does this PR do?
Fixes [CB-13570](https://issues.apache.org/jira/browse/CB-13570) on the specified platforms. Specifically, this PR changes the JS-to-native interface for the readAsX methods. Previously the JS side expected the native side to return the read value (be it a text string, ArrayBuffer, data URL, etc.) With this PR, the JS side now can handle two result formats from the native side:
1. An object like `{ value: any, numBytesConsumed: number }`, where `value` is the read value (text, ArrayBuffer, etc.) and `numBytesConsumed` is the number of bytes consumed to read that value. `numBytesConsumed` can differ from the specified `READ_CHUNK_SIZE` for reasons that will be clear shortly.
1. The previous format, for backwards compatibility with platforms/read methods that haven't yet had their native sides updated for this change.

Then, on Android, iOS, and Windows, the native side uses this new flexibility to change its handling for readAsText specifically. Depending on the specified encoding, if the end offset requested by the JS side would cause a multi-byte character to get split, the native side extends the end offset as needed to prevent splitting. The native side then returns an accurate `numBytesConsumed` to reflect the extra bytes needed.


### What testing has been done on this change?
I added an automated test that exposes the bug and now passes on the fixed platforms. I also did manual testing in the app that exposed the bug for us.

### Checklist
- [x] [Reported an issue](http://cordova.apache.org/contribute/issues.html) in the JIRA database
- [x] Commit message follows the format: "CB-3232: (android) Fix bug with resolving file paths", where CB-xxxx is the JIRA ID & "android" is the platform affected.
- [x] Added automated test coverage as appropriate for this change.
