### PR TITLE
feat(windows): known folders support

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -30,7 +30,7 @@ xmlns:android="http://schemas.android.com/apk/res/android"
     <issue>https://issues.apache.org/jira/browse/CB/component/12320651</issue>
 
     <engines>
-        <engine name="cordova-android" version=">=6.3.0" />
+        <engine name="cordova-android" version=">=6.0.0" />
     </engines>
 
     <js-module src="www/DirectoryEntry.js" name="DirectoryEntry">

--- a/src/windows/FileProxy.js
+++ b/src/windows/FileProxy.js
@@ -183,10 +183,10 @@ var windowsPaths = {
 
 if (Windows.Storage.UserDataPaths) {
     var userDataPaths = null;
-    if (typeof Windows.Storage.UserDataPaths.getDefault === "function") {
+    if (typeof Windows.Storage.UserDataPaths.getDefault === 'function') {
         userDataPaths = Windows.Storage.UserDataPaths.getDefault();
     }
-    if (!userDataPaths && typeof Windows.Storage.UserDataPaths.getForUser === "function") {
+    if (!userDataPaths && typeof Windows.Storage.UserDataPaths.getForUser === 'function') {
         userDataPaths = Windows.Storage.UserDataPaths.getForUser();
     }
     if (userDataPaths) {

--- a/src/windows/FileProxy.js
+++ b/src/windows/FileProxy.js
@@ -181,6 +181,30 @@ var windowsPaths = {
     applicationStorageDirectory: 'ms-appx:///'
 };
 
+if (Windows.Storage.UserDataPaths) {
+    var userDataPaths = null;
+	if (typeof Windows.Storage.UserDataPaths.getDefault === "function") {
+		userDataPaths = Windows.Storage.UserDataPaths.getDefault();
+	}
+	if (!userDataPaths && typeof Windows.Storage.UserDataPaths.getForUser === "function") {
+		userDataPaths = Windows.Storage.UserDataPaths.getForUser();
+	}
+	if (userDataPaths) {
+		if (userDataPaths.documents) {
+    		windowsPaths.documentsDirectory = 'file:///' + nativePathToCordova(userDataPaths.documents);
+		}
+		if (userDataPaths.music) {
+		    windowsPaths.musicDirectory = 'file:///' + nativePathToCordova(userDataPaths.music);
+		}
+		if (userDataPaths.pictures) {
+		    windowsPaths.picturesDirectory = 'file:///' + nativePathToCordova(userDataPaths.pictures);
+		}
+		if (userDataPaths.videos) {
+		    windowsPaths.videoDirectory = 'file:///' + nativePathToCordova(userDataPaths.videos);
+		}
+	}
+}
+
 var AllFileSystems;
 
 function getAllFS () {

--- a/src/windows/FileProxy.js
+++ b/src/windows/FileProxy.js
@@ -183,26 +183,26 @@ var windowsPaths = {
 
 if (Windows.Storage.UserDataPaths) {
     var userDataPaths = null;
-	if (typeof Windows.Storage.UserDataPaths.getDefault === "function") {
-		userDataPaths = Windows.Storage.UserDataPaths.getDefault();
-	}
-	if (!userDataPaths && typeof Windows.Storage.UserDataPaths.getForUser === "function") {
-		userDataPaths = Windows.Storage.UserDataPaths.getForUser();
-	}
-	if (userDataPaths) {
-		if (userDataPaths.documents) {
-    		windowsPaths.documentsDirectory = 'file:///' + nativePathToCordova(userDataPaths.documents);
-		}
-		if (userDataPaths.music) {
-		    windowsPaths.musicDirectory = 'file:///' + nativePathToCordova(userDataPaths.music);
-		}
-		if (userDataPaths.pictures) {
-		    windowsPaths.picturesDirectory = 'file:///' + nativePathToCordova(userDataPaths.pictures);
-		}
-		if (userDataPaths.videos) {
-		    windowsPaths.videoDirectory = 'file:///' + nativePathToCordova(userDataPaths.videos);
-		}
-	}
+    if (typeof Windows.Storage.UserDataPaths.getDefault === "function") {
+        userDataPaths = Windows.Storage.UserDataPaths.getDefault();
+    }
+    if (!userDataPaths && typeof Windows.Storage.UserDataPaths.getForUser === "function") {
+        userDataPaths = Windows.Storage.UserDataPaths.getForUser();
+    }
+    if (userDataPaths) {
+        if (userDataPaths.documents) {
+            windowsPaths.documentsDirectory = 'file:///' + nativePathToCordova(userDataPaths.documents);
+        }
+        if (userDataPaths.music) {
+            windowsPaths.musicDirectory = 'file:///' + nativePathToCordova(userDataPaths.music);
+        }
+        if (userDataPaths.pictures) {
+            windowsPaths.picturesDirectory = 'file:///' + nativePathToCordova(userDataPaths.pictures);
+        }
+        if (userDataPaths.videos) {
+            windowsPaths.videosDirectory = 'file:///' + nativePathToCordova(userDataPaths.videos);
+        }
+    }
 }
 
 var AllFileSystems;

--- a/www/fileSystemPaths.js
+++ b/www/fileSystemPaths.js
@@ -45,9 +45,16 @@ exports.file = {
     // iOS: Holds app-specific files that should be synced (e.g. to iCloud).
     syncedDataDirectory: null,
     // iOS: Files private to the app, but that are meaningful to other applications (e.g. Office files)
+    // Windows: Gets the path to a user's Documents folder.
     documentsDirectory: null,
     // BlackBerry10: Files globally available to all apps
-    sharedDirectory: null
+    sharedDirectory: null,
+    // Windows: Gets the path to a user's Music folder.
+    musicDirectory: null,
+    // Windows: Gets the path to a user's Pictures folder.
+    picturesDirectory: null,
+    // Windows: Gets the path to a user's Videos folder.
+    videoDirectory: null
 };
 
 channel.waitForInitialization('onFileSystemPathsReady');

--- a/www/resolveLocalFileSystemURI.js
+++ b/www/resolveLocalFileSystemURI.js
@@ -55,7 +55,7 @@
         // sanity check for 'not:valid:filename' or '/not:valid:filename'
         // file.spec.12 window.resolveLocalFileSystemURI should error (ENCODING_ERR) when resolving invalid URI with leading /.
         // now, better no check than bad check!
-        if (!uri /*|| uri.split(':').length > 2*/) {
+        if (!uri) {
             setTimeout(function () {
                 fail(FileError.ENCODING_ERR);
             }, 0);

--- a/www/resolveLocalFileSystemURI.js
+++ b/www/resolveLocalFileSystemURI.js
@@ -54,7 +54,8 @@
         };
         // sanity check for 'not:valid:filename' or '/not:valid:filename'
         // file.spec.12 window.resolveLocalFileSystemURI should error (ENCODING_ERR) when resolving invalid URI with leading /.
-        if (!uri || uri.split(':').length > 2) {
+        // now, better no check than bad check!
+        if (!uri /*|| uri.split(':').length > 2*/) {
             setTimeout(function () {
                 fail(FileError.ENCODING_ERR);
             }, 0);


### PR DESCRIPTION
Access to known user folders:
documentsDirectory: Documents, 
picturesDirectory: Pictures,
musicDirectory: Music,
videoDirectory: Videos

<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist
is intended as a quick reference, for complete details please see our Contributor Guidelines:

http://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->

### Platforms affected
Windows

### What does this PR do?
Add support for known folders. Essential feature that is needed to access any file outside of private app sandbox

Limitation:
> There is stil a problem, that working on known folders / file libraries like this will only work on Windows 10, not on 8.x
(copied from comment below)

### What testing has been done on this change?
Tested on Windows 10 Pro 1803 Build 17134.320

### Checklist
- [ ] ~~[Reported an issue](http://cordova.apache.org/contribute/issues.html) in the JIRA database~~
- [ ] ~~Commit message follows the format: "CB-3232: (android) Fix bug with resolving file paths", where CB-xxxx is the JIRA ID & "android" is the platform affected.~~
- [ ] Added automated test coverage as appropriate for this change.
