### PR TITLE
CB-13569: fix inverted LocalFileSystem enum

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -373,6 +373,6 @@ interface Cordova {
 
 
 declare enum LocalFileSystem {
-    PERSISTENT=0,
-    TEMPORARY=1
+    PERSISTENT=1,
+    TEMPORARY=0
 }


### PR DESCRIPTION
[This]( https://github.com/apache/cordova-plugin-file/pull/224) was sent by an user, but they closed it because the title was not fine and never resubmitted.

I've checked that it works without the change because it takes the JavaScript value, but changed the value in the .ts for consistency.

### Platforms affected


### What does this PR do?
Fix inverted LocalFileSystem enum

### What testing has been done on this change?


### Checklist
- [x] [Reported an issue](http://cordova.apache.org/contribute/issues.html) in the JIRA database
- [x] Commit message follows the format: "CB-3232: (android) Fix bug with resolving file paths", where CB-xxxx is the JIRA ID & "android" is the platform affected.
- [ ] Added automated test coverage as appropriate for this change.
