### PR TITLE
feat(ios): Added support for https urls access to local files.

### DIFF
--- a/src/ios/CDVFile.m
+++ b/src/ios/CDVFile.m
@@ -92,7 +92,7 @@ NSString* const kCDVFilesystemURLPrefix = @"cdvfile";
     }
     else if ([[uri scheme] isEqualToString:@"https"] && [uri pathComponents] != nil &&
              [uri pathComponents].count > 2 && [[[uri pathComponents] objectAtIndex:1] isEqualToString:@"cdvfile"]) {
-        return [pathComponents objectAtIndex:2];
+        return [[uri pathComponents] objectAtIndex:2];
     }
     else if ([[uri scheme] isEqualToString:kCDVAssetsLibraryScheme]) {
         return @"assets-library";

--- a/src/ios/CDVFile.m
+++ b/src/ios/CDVFile.m
@@ -89,7 +89,12 @@ NSString* const kCDVFilesystemURLPrefix = @"cdvfile";
         if (pathComponents != nil && pathComponents.count > 1) {
             return [pathComponents objectAtIndex:1];
         }
-    } else if ([[uri scheme] isEqualToString:kCDVAssetsLibraryScheme]) {
+    }
+    else if ([[uri scheme] isEqualToString:@"https"] && [uri pathComponents] != nil &&
+             [uri pathComponents].count > 2 && [[[uri pathComponents] objectAtIndex:1] isEqualToString:@"cdvfile"]) {
+        return [pathComponents objectAtIndex:2];
+    }
+    else if ([[uri scheme] isEqualToString:kCDVAssetsLibraryScheme]) {
         return @"assets-library";
     }
     return nil;
@@ -114,7 +119,20 @@ NSString* const kCDVFilesystemURLPrefix = @"cdvfile";
             return @"";
         }
         return [path substringFromIndex:slashRange.location];
-    } else if ([[uri scheme] isEqualToString:kCDVAssetsLibraryScheme]) {
+    }
+    else if ([[uri scheme] isEqualToString:@"https"] && [uri pathComponents] != nil &&
+             [uri pathComponents].count > 2 && [[[uri pathComponents] objectAtIndex:1] isEqualToString:@"cdvfile"]) {
+        NSString *path = [[uri path] substringFromIndex:(@"cdvfile".length + 1)];
+        if ([uri query]) {
+            path = [NSString stringWithFormat:@"%@?%@", path, [uri query]];
+        }
+        NSRange slashRange = [path rangeOfString:@"/" options:0 range:NSMakeRange(1, path.length-1)];
+        if (slashRange.location == NSNotFound) {
+            return @"";
+        }
+        return [path substringFromIndex:slashRange.location];
+    }
+    else if ([[uri scheme] isEqualToString:kCDVAssetsLibraryScheme]) {
         return [[uri absoluteString] substringFromIndex:[kCDVAssetsLibraryScheme length]+2];
     }
     return nil;
@@ -142,7 +160,9 @@ NSString* const kCDVFilesystemURLPrefix = @"cdvfile";
 + (BOOL)canInitWithRequest:(NSURLRequest*)request
 {
     NSURL* url = [request URL];
-    return [[url scheme] isEqualToString:kCDVFilesystemURLPrefix];
+    return [[url scheme] isEqualToString:kCDVFilesystemURLPrefix] ||
+        ([[url scheme] isEqualToString:@"https"] && [url pathComponents] != nil &&
+        [url pathComponents].count > 2 && [[[url pathComponents] objectAtIndex:1] isEqualToString:@"cdvfile"]);
 }
 
 + (NSURLRequest*)canonicalRequestForRequest:(NSURLRequest*)request


### PR DESCRIPTION
Currently if you load a remote https page (on domain xxx.com) on the ios webview then `cdvfile://...` urls requested from that page for active content such as js and css files are blocked by the mixed content policy.
This PR solves this by allowing access to `cdvfile://localhost/bundle/www/cordova.js` using the url: `https://xxx.com/cdvfile/bundle/www/cordova.js`
Since this url is https and from same domain as the remote https page, this works!

Reference:
https://developer.mozilla.org/en-US/docs/Web/Security/Mixed_content#Mixed_passivedisplay_content
https://developer.mozilla.org/en-US/docs/Web/Security/Mixed_content/How_to_fix_website_with_mixed_content