### PR TITLE
fix(windows): readAsArrayBuffer to use openSequentialReadAsync

### DIFF
--- a/src/windows/FileProxy.js
+++ b/src/windows/FileProxy.js
@@ -19,7 +19,7 @@
  *
 */
 
-/* global Windows, WinJS, MSApp */
+/* global Windows, WinJS */
 
 var File = require('./File');
 var FileError = require('./FileError');
@@ -660,37 +660,26 @@ module.exports = {
 
         getFileFromPathAsync(wpath).then(
             function (storageFile) {
-                var blob = MSApp.createFileFromStorageFile(storageFile);
-                var url = URL.createObjectURL(blob, { oneTimeOnly: true }); // eslint-disable-line no-undef
-                var xhr = new XMLHttpRequest(); // eslint-disable-line no-undef
-                xhr.open('GET', url, true);
-                xhr.responseType = 'arraybuffer';
-                xhr.onload = function () {
-                    var resultArrayBuffer = xhr.response;
-                    // get start and end position of bytes in buffer to be returned
-                    var startPos = args[1] || 0;
-                    var endPos = args[2] || resultArrayBuffer.length;
-                    // if any of them is specified, we'll slice output array
-                    if (startPos !== 0 || endPos !== resultArrayBuffer.length) {
-                        // slice method supported only on Windows 8.1, so we need to check if it's available
-                        // see http://msdn.microsoft.com/en-us/library/ie/dn641192(v=vs.94).aspx
-                        if (resultArrayBuffer.slice) {
-                            resultArrayBuffer = resultArrayBuffer.slice(startPos, endPos);
-                        } else {
-                            // if slice isn't available, we'll use workaround method
-                            var tempArray = new Uint8Array(resultArrayBuffer);
-                            var resBuffer = new ArrayBuffer(endPos - startPos);
-                            var resArray = new Uint8Array(resBuffer);
 
-                            for (var i = 0; i < resArray.length; i++) {
-                                resArray[i] = tempArray[i + startPos];
-                            }
-                            resultArrayBuffer = resBuffer;
-                        }
-                    }
-                    win(resultArrayBuffer);
-                };
-                xhr.send();
+                storageFile.openSequentialReadAsync().done(function (inputStream) {
+                    var startPos = args[1] || 0;
+                    inputStream.seek(startPos);
+                    var dataReader = new Windows.Storage.Streams.DataReader(inputStream);
+                    var streamSize = inputStream.size;
+                    var endPos = args[2] || (startPos + streamSize);
+                    dataReader.loadAsync(endPos - startPos).done(function (numBytes) {
+                        var bytes = new Uint8Array(numBytes);
+                        dataReader.readBytes(bytes);
+                        dataReader.close();
+                        var buf = bytes.buffer;
+                        buf = buf.slice(0, endPos - startPos);
+                        win(buf);
+                    }, function () {
+                        dataReader.close();
+                        fail(FileError.NOT_READABLE_ERR);
+                    });
+                });
+
             }, function () {
             fail(FileError.NOT_FOUND_ERR);
         }


### PR DESCRIPTION

### Platforms affected
cordova-windows


### Motivation and Context
Before this PR, readAsArrayBuffer does not work on windows 10.
This is because xhr fails with empty error.
Indeed some specs in tests fail as
![2019-03-06 11 17 22](https://user-images.githubusercontent.com/5112183/53852577-d8edfb80-4005-11e9-84ec-22eb55acbd2c.png)

This PR is to fix this issue.

### Description

Instead of using `MSApp.createFileFromStorageFile`, `URL.createObjectURL` and `XMLHttpRequest`, I used `Windows.Storage.Streams.DataReader` which is a standard method for reading binary files.

### Testing
With the help of cordova-mobile-spec, I confirmed all tests pass in cordova-plugin-file-tests.tests on Windows 10 PRO 1809.

### Checklist

- [x] I've run the tests to see all new and existing tests pass
- [ ] I added automated test coverage as appropriate for this change
- [ ] Commit is prefixed with `(platform)` if this change only applies to one platform (e.g. `(android)`)
- [ ] If this Pull Request resolves an issue, I linked to the issue in the text above (and used the correct [keyword to close issues using keywords](https://help.github.com/articles/closing-issues-using-keywords/))
- [ ] I've updated the documentation if necessary
