### PR TITLE
change nodejs version to 8 from 4.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,25 +11,25 @@ matrix:
   - env: PLATFORM=browser-firefox
     os: linux
     language: node_js
-    node_js: '4.2'
+    node_js: '8'
   - env: PLATFORM=browser-safari
     os: linux
     language: node_js
-    node_js: '4.2'
+    node_js: '8'
   - env: PLATFORM=browser-edge
     os: linux
     language: node_js
-    node_js: '4.2'
+    node_js: '8'
   - env: PLATFORM=ios-9.3
     os: osx
     osx_image: xcode7.3
     language: node_js
-    node_js: '4.2'
+    node_js: '8'
   - env: PLATFORM=ios-10.0
     os: osx
     osx_image: xcode7.3
     language: node_js
-    node_js: '4.2'
+    node_js: '8'
   - env: PLATFORM=android-4.4
     os: linux
     language: android


### PR DESCRIPTION
### Platforms affected
no platforms
only travis ci settings 


### Motivation and Context
The node.js version 4.2 is too old.
This PR updates node version to 8 in travis CI.

### Description
This PR updates node version to 8 in travis CI.

### Testing



### Checklist

- [ ] I've run the tests to see all new and existing tests pass
- [ ] I added automated test coverage as appropriate for this change
- [ ] Commit is prefixed with `(platform)` if this change only applies to one platform (e.g. `(android)`)
- [ ] If this Pull Request resolves an issue, I linked to the issue in the text above (and used the correct [keyword to close issues using keywords](https://help.github.com/articles/closing-issues-using-keywords/))
- [ ] I've updated the documentation if necessary
