### PR TITLE
feat(android): Allow loading of local file using "https://cdvfile/"

### DIFF
--- a/README.md
+++ b/README.md
@@ -470,6 +470,7 @@ my_media.play();
 
 #### cdvfile quirks
 - Using `cdvfile://` paths in the DOM is not supported on Windows platform (a path can be converted to native instead).
+- Using `cdvfile://` paths in a WebView that is loaded over https will cause a mixed content error in android. To circumvent this, use `https://cdvfile/` instead, which the browser sees as secure.
 
 
 ## List of Error Codes and Meanings

--- a/README.md
+++ b/README.md
@@ -470,7 +470,7 @@ my_media.play();
 
 #### cdvfile quirks
 - Using `cdvfile://` paths in the DOM is not supported on Windows platform (a path can be converted to native instead).
-- Using `cdvfile://` paths in a WebView that is loaded over https will cause a mixed content error in android. To circumvent this, use `https://cdvfile/` instead, which the browser sees as secure.
+- Using `cdvfile://localhost/` paths in a WebView that is loaded over https will cause a mixed content error in android. To circumvent this, use `https://cdvfile/localhost/` instead, which the browser sees as secure.
 
 
 ## List of Error Codes and Meanings

--- a/src/android/FileUtils.java
+++ b/src/android/FileUtils.java
@@ -245,6 +245,8 @@ public class FileUtils extends CordovaPlugin {
 
     @Override
     public Uri remapUri(Uri uri) {
+        uri = Uri.parse(uri.toString().replace("https://cdvfile/", "cdvfile://localhost/"));
+        
         // Remap only cdvfile: URLs (not content:).
         if (!LocalFilesystemURL.FILESYSTEM_PROTOCOL.equals(uri.getScheme())) {
             return null;

--- a/src/android/FileUtils.java
+++ b/src/android/FileUtils.java
@@ -245,7 +245,7 @@ public class FileUtils extends CordovaPlugin {
 
     @Override
     public Uri remapUri(Uri uri) {
-        uri = Uri.parse(uri.toString().replace("https://cdvfile/", "cdvfile://localhost/"));
+        uri = Uri.parse(uri.toString().replace("https://cdvfile/localhost/", "cdvfile://localhost/"));
         
         // Remap only cdvfile: URLs (not content:).
         if (!LocalFilesystemURL.FILESYSTEM_PROTOCOL.equals(uri.getScheme())) {


### PR DESCRIPTION
<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist is intended as a quick reference, for complete details please see our Contributor Guidelines:

http://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->

### Platforms affected
Android


### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
Fixes issue #295 for Android platform, without requiring to set the WebView to a less secure mixed content mode.


### Description
<!-- Describe your changes in detail -->
Allows loading of local file using "`https://cdvfile/`", which the browser sees as secure, instead of  "cdvfile://" which the browser sees as unsecure.


### Testing
<!-- Please describe in detail how you tested your changes. -->
npm test


### Checklist

- [ ] I've run the tests to see all new and existing tests pass
- [ ] I added automated test coverage as appropriate for this change
- [ ] Commit is prefixed with `(platform)` if this change only applies to one platform (e.g. `(android)`)
- [ ] If this Pull Request resolves an issue, I linked to the issue in the text above (and used the correct [keyword to close issues using keywords](https://help.github.com/articles/closing-issues-using-keywords/))
- [ ] I've updated the documentation if necessary
