### PR TITLE
ci(travis): add missing platforms

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -48,10 +48,15 @@ matrix:
       <<: *_ios
 
     # many tests with saucelabs
+    - env: PLATFORM=browser-chrome
     - env: PLATFORM=browser-firefox
     - env: PLATFORM=browser-safari
     - env: PLATFORM=browser-edge
 
+    - env: PLATFORM=ios-11.3
+      <<: *_ios
+    - env: PLATFORM=ios-12.0
+      <<: *_ios
     - env: PLATFORM=ios-12.2
       <<: *_ios
 


### PR DESCRIPTION
The Travis configuration is currently missing some platforms because there are issues:

https://github.com/apache/cordova-plugin-file/issues/326
https://github.com/apache/cordova-plugin-file/issues/327

When those are fixed, this can be merged to improve the coverage of the CI.