### PR TITLE
fix(ios) issue #349 - navigate to cdvfile with wkwebview

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -171,6 +171,7 @@ to config.xml in order for the application to find previously stored files.
                 <param name="ios-package" value="CDVFile" />
                 <param name="onload" value="true" />
             </feature>
+            <allow-navigation href="cdvfile:*" />
         </config-file>
         <header-file src="src/ios/CDVFile.h" />
         <source-file src="src/ios/CDVFile.m" />

--- a/tests/tests.js
+++ b/tests/tests.js
@@ -4160,4 +4160,30 @@ exports.defineManualTests = function (contentEl, createActionButton) {
     createActionButton('show-contact-image', function () {
         resolveFsContactImage();
     }, 'contactButton');
+
+    // This tests that we are allowed to navigate to cdvfile:// urls and
+    // that plugins are allowed to 'exec' on cdvfile urls.
+    // For exec details, see Issue 329 https://github.com/apache/cordova-plugin-file/issues/329\
+    div = document.createElement('h2');
+    div.appendChild(document.createTextNode('cdvfile:// url'));
+    div.setAttribute('align', 'center');
+    contentEl.appendChild(div);
+    div = document.createElement('div');
+    div.setAttribute('align', 'center');
+    div.innerHTML = 'clicking this button should re-load the tests page.'
+        + '<br>You should be able to run all the tests successfully after the page re-load.'
+        + '<br>NOTE: This will not work if you are not on file:// url to start.'
+        + '<br>eg. You are using an http server to hot re-load client-side files.';
+    contentEl.appendChild(div);
+    div = document.createElement('div');
+    div.setAttribute('id', 'cdvfilePageTests');
+    div.setAttribute('align', 'center');
+    contentEl.appendChild(div);
+    createActionButton('Navigate to cdvfile:// url', function () {
+        // Get current page's cdvfile Url
+        window.resolveLocalFileSystemURL(window.location.href, function (entry) {
+            var cdvfileUrl = entry.toInternalURL();
+            window.location.href = cdvfileUrl;
+        });
+    }, 'cdvfilePageTests');
 };


### PR DESCRIPTION
<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist is intended as a quick reference, for complete details please see our Contributor Guidelines:

http://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->

### Platforms affected
iOS


### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
Fixes #349
This issue is only present when using the wkwebview engine, but since that is the future of iOS this should be addressed.  The wkWebview does not allow unknown schemes (eg. `cdvfile://`).


### Description
<!-- Describe your changes in detail -->
These changes intercept navigation requests and check if the url is a `cdvfile://` url.  If it is, it stops the request and creates a new request for the equivalent `file://` url.

Alternative solution:
Use a similar workaround to what is proposed by @guylando in pull request #296.  This will get us past the unknown scheme, but I'm not sure how to get it to return the correct file from there.  (Other than loading a request for the equivalent `file://` url).

Future (better) solution:
When the lowest cordova supported iOS version is 11.0 this work-around can potentially be removed.  WKWebview for iOS 11+ supports "WKURLSchemeHandler" and "setURLSchemeHandler" which should allow actual support for the cdvfile scheme.

Advice requested:
This is my first foray into objc and the ios side of cordova-plugin-file.
* I'm not sure if my method `nativeUrlFromCdvfileUrl` is the most efficient way to get the equivalent `file://` url, please advise. 
* This addition basically allows you to do `window.location.href = 'cdvfile://...';`  but the `window.location.href` after the page load will actually be `file://...`, can anyone see any issues that this could cause?  (Especially issues that could be worse than not being able to navigate to `cdvfile://` url at all?)

### Testing
<!-- Please describe in detail how you tested your changes. -->
Tested on ios 9.3.5 and 10.3.4 devices.  Tested with and without wkwebview.
Ran `npm test` passed.
Ran the automatic tests.  No change from before and after the change.  (One test failed before and after the additions (on andriod and ios), reported in issue #357)


### Checklist

- [x] I've run the tests to see all new and existing tests pass
- [x] I added automated (manual) test coverage as appropriate for this change
- [x] Commit is prefixed with `(platform)` if this change only applies to one platform (e.g. `(android)`)
- [x] If this Pull Request resolves an issue, I linked to the issue in the text above (and used the correct [keyword to close issues using keywords](https://help.github.com/articles/closing-issues-using-keywords/))
- [x] I've updated the documentation if necessary
