### PR TITLE
(windows) Fixes #362

### DIFF
--- a/src/windows/FileProxy.js
+++ b/src/windows/FileProxy.js
@@ -157,8 +157,8 @@ var WinFS = function (name, root) {
         // CB-11848: This RE supposed to match all leading slashes in sanitized path.
         // Removing leading slash to avoid duplicating because this.root.nativeURL already has trailing slash
         var regLeadingSlashes = /^\/*/;
-        var sanitizedPath = sanitize(path.replace(':', '%3A')).replace(regLeadingSlashes, '');
-        return FileSystem.encodeURIPath(this.root.nativeURL + sanitizedPath);
+        var sanitizedPath = sanitize(path).replace(regLeadingSlashes, '');
+        return FileSystem.encodeURIPath(this.root.nativeURL + sanitizedPath).replace(/\/(\w):\//, '/$1%3A/');
     };
     root.fullPath = '/';
     if (!root.nativeURL) { root.nativeURL = 'file://' + sanitize(this.winpath + root.fullPath).replace(':', '%3A'); }


### PR DESCRIPTION
### Platforms affected
Windows


### Motivation and Context
Fix #362

### Checklist

- [+] I've run the tests to see all new and existing tests pass
- [-] I added automated test coverage as appropriate for this change
- [+] Commit is prefixed with `(platform)` if this change only applies to one platform (e.g. `(android)`)
- [+] If this Pull Request resolves an issue, I linked to the issue in the text above (and used the correct [keyword to close issues using keywords](https://help.github.com/articles/closing-issues-using-keywords/))
- [-] I've updated the documentation if necessary
