### PR TITLE
Save the file API before overwrite

### DIFF
--- a/www/File.js
+++ b/www/File.js
@@ -28,6 +28,8 @@
  * size {Number} size of the file in bytes
  */
 
+window['OriginalFileApi'] = window.File;
+
 var File = function (name, localURL, type, lastModifiedDate, size) {
     this.name = name || '';
     this.localURL = localURL || null;


### PR DESCRIPTION
This PR saves the File API before overwrite. Even though this does not solve #316 or #265, at least it allows the applications to still use the native File API. 