### PR TITLE
fix(android): Use legacy storage

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -132,7 +132,9 @@ to config.xml in order for the application to find previously stored files.
             </feature>
             <allow-navigation href="cdvfile:*" />
         </config-file>
-
+        <edit-config file="app/src/main/AndroidManifest.xml" mode="merge" target="/manifest/application">
+            <application android:requestLegacyExternalStorage="true" />
+        </edit-config>
         <config-file target="AndroidManifest.xml" parent="/*">
             <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
         </config-file>


### PR DESCRIPTION
<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist is intended as a quick reference, for complete details please see our Contributor Guidelines:

http://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->

### Platforms affected

Android

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

Required when targeting API 29, which is the default target API on `cordova-android@9`. This is a fork of a broken PR https://github.com/apache/cordova-plugin-file/pull/410

Closes #410 
Fixes #408 
Required for https://github.com/apache/cordova-plugin-media-capture/issues/103


### Description
<!-- Describe your changes in detail -->

Adds `requestLegacyExternalStorage` flag to `AndroidManifest.xml`

### Testing
<!-- Please describe in detail how you tested your changes. -->
Tested against https://github.com/apache/cordova-plugin-media-capture/pull/192#pullrequestreview-487221746


### Checklist

- [x] I've run the tests to see all new and existing tests pass
- [x] I added automated test coverage as appropriate for this change
- [x] Commit is prefixed with `(platform)` if this change only applies to one platform (e.g. `(android)`)
- [x] If this Pull Request resolves an issue, I linked to the issue in the text above (and used the correct [keyword to close issues using keywords](https://help.github.com/articles/closing-issues-using-keywords/))
- [x] I've updated the documentation if necessary
