### PR TITLE
chore: bump version to 7.0.0-dev

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cordova-plugin-file",
-  "version": "6.0.3-dev",
+  "version": "7.0.0-dev",
   "description": "Cordova File Plugin",
   "types": "./types/index.d.ts",
   "cordova": {
@@ -36,7 +36,7 @@
       "5.0.0": {
         "cordova-android": ">=6.3.0"
       },
-      "7.0.0": {
+      "8.0.0": {
         "cordova": ">100"
       }
     }

--- a/plugin.xml
+++ b/plugin.xml
@@ -21,7 +21,7 @@
 <plugin xmlns="http://apache.org/cordova/ns/plugins/1.0"
 xmlns:android="http://schemas.android.com/apk/res/android"
            id="cordova-plugin-file"
-      version="6.0.3-dev">
+      version="7.0.0-dev">
     <name>File</name>
     <description>Cordova File Plugin</description>
     <license>Apache 2.0</license>

--- a/tests/plugin.xml
+++ b/tests/plugin.xml
@@ -21,7 +21,7 @@
 <plugin xmlns="http://apache.org/cordova/ns/plugins/1.0"
     xmlns:android="http://schemas.android.com/apk/res/android"
     id="cordova-plugin-file-tests"
-    version="6.0.3-dev">
+    version="7.0.0-dev">
 
     <name>Cordova File Plugin Tests</name>
     <license>Apache 2.0</license>


### PR DESCRIPTION
<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist is intended as a quick reference, for complete details please see our Contributor Guidelines:

http://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->

### Platforms affected
all


### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
A change was introduced that forces new requirements, thus a major version bump is necessary.

The offending change is located at: https://github.com/apache/cordova-plugin-file/pull/417 which is required to use file directories outside of the app's private data directory.

This relates to https://github.com/apache/cordova-plugin-file/issues/424 but doesn't resolve it. I'll be creating another PR shortly to complete the resolution.

### Description
<!-- Describe your changes in detail -->

Bump version numbers.


### Testing
<!-- Please describe in detail how you tested your changes. -->

N/A

### Checklist

- [x] I've run the tests to see all new and existing tests pass
- [x] I added automated test coverage as appropriate for this change
- [x] Commit is prefixed with `(platform)` if this change only applies to one platform (e.g. `(android)`)
- [x] If this Pull Request resolves an issue, I linked to the issue in the text above (and used the correct [keyword to close issues using keywords](https://help.github.com/articles/closing-issues-using-keywords/))
- [x] I've updated the documentation if necessary
