### PR TITLE
fix(android): Fix deprecated left shift usage (support was removed in Gradle 5)

### DIFF
--- a/src/android/build-extras.gradle
+++ b/src/android/build-extras.gradle
@@ -19,25 +19,27 @@
 ext.postBuildExtras = {
     def inAssetsDir = file("assets")
     def outAssetsDir = inAssetsDir
+    outAssetsDir.mkdirs()
     def outFile = new File(outAssetsDir, "cdvasset.manifest")
 
-    def newTask = task("cdvCreateAssetManifest") << {
-        def contents = new HashMap()
-        def sizes = new HashMap()
-        contents[""] = inAssetsDir.list()
-        def tree = fileTree(dir: inAssetsDir)
-        tree.visit { fileDetails ->
-            if (fileDetails.isDirectory()) {
-                contents[fileDetails.relativePath.toString()] = fileDetails.file.list()
-            } else {
-                sizes[fileDetails.relativePath.toString()] = fileDetails.file.length()
+    def newTask = task("cdvCreateAssetManifest") {
+        doLast {
+            def contents = new HashMap()
+            def sizes = new HashMap()
+            contents["test"] = inAssetsDir.list()
+            def tree = fileTree(dir: inAssetsDir)
+            tree.visit { fileDetails ->
+                if (fileDetails.isDirectory()) {
+                    contents[fileDetails.relativePath.toString()] = fileDetails.file.list()
+                } else {
+                    sizes[fileDetails.relativePath.toString()] = fileDetails.file.length()
+                }
             }
-        }
 
-        outAssetsDir.mkdirs()
-        outFile.withObjectOutputStream { oos ->
-            oos.writeObject(contents)
-            oos.writeObject(sizes)
+            outFile.withObjectOutputStream { oos ->
+                oos.writeObject(contents)
+                oos.writeObject(sizes)
+            }
         }
     }
     newTask.inputs.dir inAssetsDir


### PR DESCRIPTION


<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist is intended as a quick reference, for complete details please see our Contributor Guidelines:

http://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->

### Platforms affected

Android

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

Fixes #425
Also required for #471 

### Description
<!-- Describe your changes in detail -->

Removed deprecated `<<` syntax in Gradle (`<<` support was removed in Gradle 5) and replaced it with the equivalent. 

### Testing
<!-- Please describe in detail how you tested your changes. -->

Manual tests

### Checklist

- [x] I've run the tests to see all new and existing tests pass
- [x] I added automated test coverage as appropriate for this change
- [x] Commit is prefixed with `(platform)` if this change only applies to one platform (e.g. `(android)`)
- [x] If this Pull Request resolves an issue, I linked to the issue in the text above (and used the correct [keyword to close issues using keywords](https://help.github.com/articles/closing-issues-using-keywords/))
- [x] I've updated the documentation if necessary
