### PR TITLE
fix(gh-action): remove codevcov action

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,7 +55,3 @@ jobs:
           npm t
         env:
           CI: true
-
-      - uses: codecov/codecov-action@v1
-        with:
-          fail_ci_if_error: true


### PR DESCRIPTION
### Motivation, Context & Description

Remove the GitHub Actions CodeCov step.

None of our plugins have any tests to run and generate a coverage report; there for nothing is being sent to and causes the coverage step to fail.