### PR TITLE
feat: Request external permission when listing external directories

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,7 +160,7 @@ the `cordova.file.*` properties map to physical paths on a real device.
 | &nbsp;&nbsp;&nbsp;`cache`                       | cacheDirectory              | cache                     | r/w  |     Yes     |     Yes\* |   Yes   |
 | &nbsp;&nbsp;&nbsp;`files`                       | dataDirectory               | files                     | r/w  |     Yes     |     No    |   Yes   |
 | &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;`Documents` |                             | documents                 | r/w  |     Yes     |     No    |   Yes   |
-| `<sdcard>/`                                     | externalRootDirectory       | sdcard                    | r/w  |     Yes     |     No    |   No    |
+| `<sdcard>/`                                     | externalRootDirectory       | sdcard                    | r/w\*\*\*  |     Yes     |     No    |   No    |
 | &nbsp;&nbsp;&nbsp;`Android/data/<app-id>/`      | externalApplicationStorageDirectory | -                 | r/w  |     Yes     |     No    |   No    |
 | &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;`cache`     | externalCacheDirectory       | cache-external            | r/w  |     Yes     |     No\*\*|   No    |
 | &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;`files`     | externalDataDirectory       | files-external            | r/w  |     Yes     |     No    |   No    |
@@ -172,6 +172,8 @@ the `cordova.file.*` properties map to physical paths on a real device.
 \*\* The OS does not clear this directory automatically; you are responsible for managing
      the contents yourself. Should the user purge the cache manually, the contents of the
      directory are removed.
+
+\*\*\* As of API 30, these directories are no longer writable.
 
 **Note**: If external storage can't be mounted, the `cordova.file.external*`
 properties are `null`.

--- a/plugin.xml
+++ b/plugin.xml
@@ -132,9 +132,6 @@ to config.xml in order for the application to find previously stored files.
             </feature>
             <allow-navigation href="cdvfile:*" />
         </config-file>
-        <edit-config file="app/src/main/AndroidManifest.xml" mode="merge" target="/manifest/application">
-            <application android:requestLegacyExternalStorage="true" />
-        </edit-config>
         <config-file target="AndroidManifest.xml" parent="/*">
             <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
         </config-file>


### PR DESCRIPTION
<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist is intended as a quick reference, for complete details please see our Contributor Guidelines:

http://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->

### Platforms affected
Android


### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

Progresses https://github.com/apache/cordova-plugin-file/issues/426 but unsure if it completely resolves it

### Description
<!-- Describe your changes in detail -->

Code changes includes checking to see the file path on reading directory listings (for listing directories and files) and if the file path happens to be an "external" file path, then assert/request READ_EXTERNAL_STORAGE permission.

There have been a couple of documentation changes as well, including the fact that some directories that were previously writable in earlier API versions are no longer writable starting in API 30.

`requestLegacyExternalStorage` flag is removed because that was an API 29 only flag. This flag is not honoured on API 30 and is forcefully false.

### Testing
<!-- Please describe in detail how you tested your changes. -->

Npm test and manual testing using a test app: https://github.com/breautek/cordova-file-api30-test-app

I'm not sure if my test app is an exhaustive list, but the basic directory listing, reading and writing all appear to work properly assuming the app has the READ/WRITE_EXTERNAL_STORAGE permission granted.

CDVFILE urls however don't quite work as expected and is not covered in this PR. If a cdvfile url leads to an external directory source and the app does not have the proper permissions, the webview does not wait for the permission response and the request will fail. From what I can tell, cdvfile-based urls do work if the app already has the permission granted.

### Checklist

- [x] I've run the tests to see all new and existing tests pass
- [x] I added automated test coverage as appropriate for this change
- [x] Commit is prefixed with `(platform)` if this change only applies to one platform (e.g. `(android)`)
- [x] If this Pull Request resolves an issue, I linked to the issue in the text above (and used the correct [keyword to close issues using keywords](https://help.github.com/articles/closing-issues-using-keywords/))
- [x] I've updated the documentation if necessary
