### PR TITLE
test: remove deprecated cordova-plugin-contact tests

### DIFF
--- a/tests/plugin.xml
+++ b/tests/plugin.xml
@@ -38,6 +38,5 @@
                 android:exported="false" />
         </config-file>
         <asset src="www/fixtures/asset-test" target="fixtures/asset-test" />
-        <dependency id="cordova-plugin-contacts" />
     </platform>
 </plugin>

--- a/tests/tests.js
+++ b/tests/tests.js
@@ -4171,37 +4171,6 @@ exports.defineManualTests = function (contentEl, createActionButton) {
         }, logError('requestFileSystem'));
     }
 
-    function resolveFsContactImage () {
-        navigator.contacts.pickContact(function (contact) {
-            var logBox = document.getElementById('logContactBox');
-            logBox.innerHTML = '';
-            var resolveResult = document.createElement('p');
-            if (contact.photos) {
-                var photoURL = contact.photos[0].value;
-                resolveLocalFileSystemURL(photoURL, function (entry) {
-                    /* eslint-enable no-undef */
-                    var contactImage = document.createElement('img');
-                    var contactLabelImage = document.createElement('p');
-                    contactLabelImage.innerHTML = 'Result contact image';
-                    contactImage.setAttribute('src', entry.toURL());
-                    resolveResult.innerHTML = 'Success resolve\n' + entry.toURL();
-                    logBox.appendChild(contactLabelImage);
-                    logBox.appendChild(contactImage);
-                    logBox.appendChild(resolveResult);
-                },
-                function (err) {
-                    console.log('resolve error' + err);
-                });
-            } else {
-                resolveResult.innerHTML = 'Contact has no photos';
-                logBox.appendChild(resolveResult);
-            }
-        },
-        function (err) {
-            console.log('contact pick error' + err);
-        });
-    }
-
     function clearLog () {
         var log = document.getElementById('info');
         log.innerHTML = '';
@@ -4285,18 +4254,4 @@ exports.defineManualTests = function (contentEl, createActionButton) {
     div.appendChild(document.createTextNode('Resolving content urls'));
     div.setAttribute('align', 'center');
     contentEl.appendChild(div);
-
-    div = document.createElement('div');
-    div.setAttribute('id', 'contactButton');
-    div.setAttribute('align', 'center');
-    contentEl.appendChild(div);
-
-    div = document.createElement('div');
-    div.setAttribute('id', 'logContactBox');
-    div.setAttribute('align', 'center');
-    contentEl.appendChild(div);
-
-    createActionButton('show-contact-image', function () {
-        resolveFsContactImage();
-    }, 'contactButton');
 };


### PR DESCRIPTION
### Motivation and Context

Cordova Contact Plugin has been deprecated and should be removed.

### Description

* Removed dependency
* Removed test releated code.

### Testing

n/a

### Checklist

- [ ] I've run the tests to see all new and existing tests pass
- [ ] I added automated test coverage as appropriate for this change
- [ ] Commit is prefixed with `(platform)` if this change only applies to one platform (e.g. `(android)`)
- [ ] If this Pull Request resolves an issue, I linked to the issue in the text above (and used the correct [keyword to close issues using keywords](https://help.github.com/articles/closing-issues-using-keywords/))
- [ ] I've updated the documentation if necessary
