### PR TITLE
Make types compatible with Typescript 4.4

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ Although the object is in the global scope, it is not available to applications 
 
 As of v1.2.0, URLs to important file-system directories are provided.
 Each URL is in the form _file:///path/to/spot/_, and can be converted to a
-`DirectoryEntry` using `window.resolveLocalFileSystemURL()`.
+`FileSystemDirectoryEntry` using `window.resolveLocalFileSystemURL()`.
 
 * `cordova.file.applicationDirectory` - Read-only directory where the application
   is installed. (_iOS_, _Android_, _BlackBerry 10_, _OSX_, _windows_)
@@ -342,7 +342,7 @@ You can use `window.isFilePluginReadyRaised` function to check whether event was
 - window.requestFileSystem TEMPORARY and PERSISTENT filesystem quotas are not limited in Chrome.
 - To increase persistent storage in Chrome you need to call `window.initPersistentFileSystem` method. Persistent storage quota is 5 MB by default.
 - Chrome requires `--allow-file-access-from-files` run argument to support API via `file:///` protocol.
-- `File` object will be not changed if you use flag `{create:true}` when getting an existing `Entry`.
+- `File` object will be not changed if you use flag `{create:true}` when getting an existing `FileSystemEntry`.
 - events `cancelable` property is set to true in Chrome. This is contrary to the [specification](http://dev.w3.org/2009/dap/file-system/file-writer.html).
 - `toURL` function in Chrome returns `filesystem:`-prefixed path depending on application host.
 For example, `filesystem:file:///persistent/somefile.txt`, `filesystem:http://localhost:8080/persistent/somefile.txt`.
@@ -366,13 +366,13 @@ once you hit that level you will be asked if you want to allow it to be increase
 So `size` parameter for `requestFileSystem` function does not affect filesystem in Firefox and IE.
 - `readAsBinaryString` function is not stated in the Specs and not supported in IE and does not have a stub.
 - `file.type` is always null.
-- You should not create entry using DirectoryEntry instance callback result which was deleted.
+- You should not create entry using FileSystemDirectoryEntry instance callback result which was deleted.
 Otherwise, you will get a 'hanging entry'.
 - Before you can read a file, which was just written you need to get a new instance of this file.
 - `setMetadata` function, which is not stated in the Specs supports `modificationTime` field change only.
 - `copyTo` and `moveTo` functions do not support directories.
 - Directories metadata is not supported.
-- Both Entry.remove and directoryEntry.removeRecursively don't fail when removing
+- Both FileSystemEntry.remove and directoryEntry.removeRecursively don't fail when removing
 non-empty directories - directories being removed are cleaned along with contents instead.
 - `abort` and `truncate` functions are not supported.
 - progress events are not fired. For example, this handler will be not executed:

--- a/doc/plugins.md
+++ b/doc/plugins.md
@@ -27,7 +27,7 @@ Working with Cordova file system URLs
 
 Since version 1.0.0, this plugin has used URLs with a `cdvfile` scheme for all communication over the bridge, rather than exposing raw device file system paths to JavaScript. 
 
-On the JavaScript side, this means that FileEntry and DirectoryEntry objects have a fullPath attribute which is relative to the root of the HTML file system. If your plugin's JavaScript API accepts a FileEntry or DirectoryEntry object, you should call `.toURL()` on that object before passing it across the bridge to native code.
+On the JavaScript side, this means that FileSystemFileEntry and FileSystemDirectoryEntry objects have a fullPath attribute which is relative to the root of the HTML file system. If your plugin's JavaScript API accepts a FileSystemFileEntry or FileSystemDirectoryEntry object, you should call `.toURL()` on that object before passing it across the bridge to native code.
 
 ### Converting cdvfile:// URLs to fileystem paths
 
@@ -104,7 +104,7 @@ If your plugin creates a file, and you want to return a FileEntry object for it,
 
 #### JavaScript
 
-In JavaScript, to get a `cdvfile://` URL from a FileEntry or DirectoryEntry object, simply call `.toURL()` on it:
+In JavaScript, to get a `cdvfile://` URL from a FileSystemFileEntry or FileSystemDirectoryEntry object, simply call `.toURL()` on it:
 
     var cdvfileURL = entry.toURL();
 

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -20,50 +20,51 @@ interface Window {
         successCallback: (fileSystem: FileSystem) => void,
         errorCallback?: (fileError: FileError) => void): void;
     /**
-     * Look up file system Entry referred to by local URL.
+     * Look up file system FileSystemEntry referred to by local URL.
      * @param string url       URL referring to a local file or directory
-     * @param successCallback  invoked with Entry object corresponding to URL
+     * @param successCallback  invoked with FileSystemEntry object corresponding to URL
      * @param errorCallback    invoked if error occurs retrieving file system entry
      */
     resolveLocalFileSystemURL(url: string,
-        successCallback: (entry: Entry) => void,
+        successCallback: (entry: FileSystemEntry) => void,
         errorCallback?: (error: FileError) => void): void;
     /**
-     * Look up file system Entry referred to by local URI.
+     * Look up file system FileSystemEntry referred to by local URI.
      * @param string uri       URI referring to a local file or directory
-     * @param successCallback  invoked with Entry object corresponding to URI
+     * @param successCallback  invoked with FileSystemEntry object corresponding to URI
      * @param errorCallback    invoked if error occurs retrieving file system entry
      */
     resolveLocalFileSystemURI(uri: string,
-        successCallback: (entry: Entry) => void,
+        successCallback: (entry: FileSystemEntry) => void,
         errorCallback?: (error: FileError) => void): void;
     TEMPORARY: number;
     PERSISTENT: number;
 }
 
 /** This interface represents a file system. */
-interface FileSystem {
-    /* The name of the file system, unique across the list of exposed file systems. */
-    name: string;
-    /** The root directory of the file system. */
-    root: DirectoryEntry;
-}
+// Commented in order to avoid conflicts with lib.dom.d.ts
+// interface FileSystem {
+//     /* The name of the file system, unique across the list of exposed file systems. */
+//     name: string;
+//     /** The root directory of the file system. */
+//     root: FileSystemDirectoryEntry;
+// }
 
 /**
  * An abstract interface representing entries in a file system,
- * each of which may be a File or DirectoryEntry.
+ * each of which may be a File or FileSystemDirectoryEntry.
  */
-interface Entry {
-    /** Entry is a file. */
-    isFile: boolean;
-    /** Entry is a directory. */
-    isDirectory: boolean;
+interface FileSystemEntry {
+    /** FileSystemEntry is a file. */
+    // isFile: boolean;
+    /** FileSystemEntry is a directory. */
+    // isDirectory: boolean;
     /** The name of the entry, excluding the path leading to it. */
-    name: string;
+    // name: string;
     /** The full absolute path from the root to the entry. */
-    fullPath: string;
+    // fullPath: string;
     /** The file system on which the entry resides. */
-    filesystem: FileSystem;
+    // filesystem: FileSystem;
     nativeURL: string;
     /**
      * Look up metadata about this entry.
@@ -82,13 +83,13 @@ interface Entry {
      * A move of a file on top of an existing file must attempt to delete and replace that file.
      * A move of a directory on top of an existing empty directory must attempt to delete and replace that directory.
      * @param parent  The directory to which to move the entry.
-     * @param newName The new name of the entry. Defaults to the Entry's current name if unspecified.
-     * @param successCallback A callback that is called with the Entry for the new location.
+     * @param newName The new name of the entry. Defaults to the FileSystemEntry's current name if unspecified.
+     * @param successCallback A callback that is called with the FileSystemEntry for the new location.
      * @param errorCallback   A callback that is called when errors happen.
      */
-    moveTo(parent: DirectoryEntry,
+    moveTo(parent: FileSystemDirectoryEntry,
         newName?: string,
-        successCallback?: (entry: Entry) => void,
+        successCallback?: (entry: FileSystemEntry) => void,
         errorCallback?: (error: FileError) => void): void;
     /**
      * Copy an entry to a different location on the file system. It is an error to try to:
@@ -101,13 +102,13 @@ interface Entry {
      *     A copy of a directory on top of an existing empty directory must attempt to delete and replace that directory.
      * Directory copies are always recursive--that is, they copy all contents of the directory.
      * @param parent The directory to which to move the entry.
-     * @param newName The new name of the entry. Defaults to the Entry's current name if unspecified.
-     * @param successCallback A callback that is called with the Entry for the new object.
+     * @param newName The new name of the entry. Defaults to the FileSystemEntry's current name if unspecified.
+     * @param successCallback A callback that is called with the FileSystemEntry for the new object.
      * @param errorCallback A callback that is called when errors happen.
      */
-    copyTo(parent: DirectoryEntry,
+    copyTo(parent: FileSystemDirectoryEntry,
         newName?: string,
-        successCallback?: (entry: Entry) => void,
+        successCallback?: (entry: FileSystemEntry) => void,
         errorCallback?: (error: FileError) => void): void;
     /**
      * Returns a URL that can be used as the src attribute of a <video> or <audio> tag.
@@ -128,11 +129,11 @@ interface Entry {
     remove(successCallback: () => void,
         errorCallback?: (error: FileError) => void): void;
     /**
-     * Look up the parent DirectoryEntry containing this Entry. If this Entry is the root of its filesystem, its parent is itself.
+     * Look up the parent FileSystemDirectoryEntry containing this FileSystemEntry. If this FileSystemEntry is the root of its filesystem, its parent is itself.
      * @param successCallback A callback that is called with the time of the last modification.
      * @param errorCallback   A callback that is called when errors happen.
      */
-    getParent(successCallback: (entry: Entry) => void,
+    getParent(successCallback: (entry: FileSystemEntry) => void,
         errorCallback?: (error: FileError) => void): void;
 }
 
@@ -145,42 +146,42 @@ interface Metadata {
 }
 
 /** This interface represents a directory on a file system. */
-interface DirectoryEntry extends Entry {
+interface FileSystemDirectoryEntry extends FileSystemEntry {
     /**
      * Creates a new DirectoryReader to read Entries from this Directory.
      */
     createReader(): DirectoryReader;
     /**
      * Creates or looks up a file.
-     * @param path    Either an absolute path or a relative path from this DirectoryEntry
+     * @param path    Either an absolute path or a relative path from this FileSystemDirectoryEntry
      *                to the file to be looked up or created.
      *                It is an error to attempt to create a file whose immediate parent does not yet exist.
      * @param options If create and exclusive are both true, and the path already exists, getFile must fail.
-     *                If create is true, the path doesn't exist, and no other error occurs, getFile must create it as a zero-length file and return a corresponding FileEntry.
+     *                If create is true, the path doesn't exist, and no other error occurs, getFile must create it as a zero-length file and return a corresponding FileSystemFileEntry.
      *                If create is not true and the path doesn't exist, getFile must fail.
      *                If create is not true and the path exists, but is a directory, getFile must fail.
-     *                Otherwise, if no other error occurs, getFile must return a FileEntry corresponding to path.
+     *                Otherwise, if no other error occurs, getFile must return a FileSystemFileEntry corresponding to path.
      * @param successCallback A callback that is called to return the File selected or created.
      * @param errorCallback   A callback that is called when errors happen.
      */
     getFile(path: string, options?: Flags,
-        successCallback?: (entry: FileEntry) => void,
+        successCallback?: (entry: FileSystemFileEntry) => void,
         errorCallback?: (error: FileError) => void): void;
     /**
      * Creates or looks up a directory.
-     * @param path    Either an absolute path or a relative path from this DirectoryEntry
+     * @param path    Either an absolute path or a relative path from this FileSystemDirectoryEntry
      *                to the directory to be looked up or created.
      *                It is an error to attempt to create a directory whose immediate parent does not yet exist.
      * @param options If create and exclusive are both true and the path already exists, getDirectory must fail.
-     *                If create is true, the path doesn't exist, and no other error occurs, getDirectory must create and return a corresponding DirectoryEntry.
+     *                If create is true, the path doesn't exist, and no other error occurs, getDirectory must create and return a corresponding FileSystemDirectoryEntry.
      *                If create is not true and the path doesn't exist, getDirectory must fail.
      *                If create is not true and the path exists, but is a file, getDirectory must fail.
-     *                Otherwise, if no other error occurs, getDirectory must return a DirectoryEntry corresponding to path.
+     *                Otherwise, if no other error occurs, getDirectory must return a FileSystemDirectoryEntry corresponding to path.
      * @param successCallback A callback that is called to return the Directory selected or created.
      * @param errorCallback   A callback that is called when errors happen.
      */
     getDirectory(path: string, options?: Flags,
-        successCallback?: (entry: DirectoryEntry) => void,
+        successCallback?: (entry: FileSystemDirectoryEntry) => void,
         errorCallback?: (error: FileError) => void): void;
     /**
      * Deletes a directory and all of its contents, if any. In the event of an error (e.g. trying
@@ -223,14 +224,14 @@ interface DirectoryReader {
      * @param errorCallback   A callback indicating that there was an error reading from the Directory.
      */
     readEntries(
-        successCallback: (entries: Entry[]) => void,
+        successCallback: (entries: FileSystemEntry[]) => void,
         errorCallback?: (error: FileError) => void): void;
 }
 
 /** This interface represents a file on a file system. */
-interface FileEntry extends Entry {
+interface FileSystemFileEntry extends FileSystemEntry {
     /**
-     * Creates a new FileWriter associated with the file that this FileEntry represents.
+     * Creates a new FileWriter associated with the file that this FileSystemFileEntry represents.
      * @param successCallback A callback that is called with the new FileWriter.
      * @param errorCallback   A callback that is called when errors happen.
      */
@@ -238,7 +239,7 @@ interface FileEntry extends Entry {
         writer: FileWriter) => void,
         errorCallback?: (error: FileError) => void): void;
     /**
-     * Returns a File that represents the current state of the file that this FileEntry represents.
+     * Returns a File that represents the current state of the file that this FileSystemFileEntry represents.
      * @param successCallback A callback that is called with the File.
      * @param errorCallback   A callback that is called when errors happen.
      */


### PR DESCRIPTION
### Platforms affected
None, Typescript type definition only


### Motivation and Context
Typescript 4.4 has introduced a lot of changes in `lib.dom.d.ts` file, which raises a lot of compilation errors with the plugin.
These changes makes it compatible with it.


### Description
- `Entry` renamed to `FileSystemEntry`
- `FileEntry` renamed to `FileSystemFileEntry`
- `DirectoryEntry` renamed to `FileSystemDirectoryEntry`
- Commented `FileSystem` interface which already exists into `lib.dom.d.ts`
- Commented field duplications for those interfaces, to avoid error `TS2687`
```
     error TS2687: All declarations of 'xxx' must have identical modifiers.
````

Most of the changes are naming changes to follow Typescript renames.

However, this may require some changes on the application side if :
- the old Type names were referenced in your code (migrate them to the new name, or make type alias with the old name if there are too much occurences of it in your code)
- If you are on a TS version older than 4.4, you may miss the commented parts if you were relying on it in your code. In that case, I'd suggest to declare following interfaces somewhere in your code : 
```
declare interface FileSystem {
    /* The name of the file system, unique across the list of exposed file systems. */
    name: string;
    /** The root directory of the file system. */
    root: FileSystemDirectoryEntry;
}

declare interface FileSystemEntry {
    /** FileSystemEntry is a file. */
    isFile: boolean;
    /** FileSystemEntry is a directory. */
    isDirectory: boolean;
    /** The name of the entry, excluding the path leading to it. */
    name: string;
    /** The full absolute path from the root to the entry. */
    fullPath: string;
    /** The file system on which the entry resides. */
    filesystem: FileSystem;
}
```

⚠️ Important notes : 
- I updated `doc/plugins.md` file to reflect the naming changes, but I'm unsure of the pertinence of it given that we're going to have discrepancies (in namings) between native code's semantics and javascript's semantic. I can rollback these change if you prefer.
- Some care should be added to the `README`'s `Upgrading notes` section to pinpoint these changes (I didn't added any entry as I don't know which version of the plugin may be concerned by this change)

### Testing
There wasn't any TS-based tests in place currently, didn't spent time to introduce it as I'd consider it as a whole dedicated topic.

### Checklist

- [x] I've run the tests to see all new and existing tests pass
- [ ] I added automated test coverage as appropriate for this change.
- [ ] Commit is prefixed with `(platform)` if this change only applies to one platform (e.g. `(android)`)
- [ ] If this Pull Request resolves an issue, I linked to the issue in the text above (and used the correct [keyword to close issues using keywords](https://help.github.com/articles/closing-issues-using-keywords/))
- [x] I've updated the documentation if necessary
