### PR TITLE
fix(android): create toURL override to preserve other platforms

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -154,6 +154,9 @@ to config.xml in order for the application to find previously stored files.
         <framework src="androidx.webkit:webkit:$ANDROIDX_WEBKIT_VERSION" />
 
         <!-- android specific file apis -->
+        <js-module src="www/android/Entry.js" name="androidEntry">
+            <merges target="Entry" />
+        </js-module>
         <js-module src="www/android/FileSystem.js" name="androidFileSystem">
             <merges target="FileSystem" />
         </js-module>

--- a/www/Entry.js
+++ b/www/Entry.js
@@ -187,12 +187,15 @@ Entry.prototype.toInternalURL = function () {
 /**
  * Return a URL that can be used to identify this entry.
  * Use a URL that can be used to as the src attribute of a <video> or
- * <audio> tag. If that is not possible, construct a http(s)://(localhost) URL.
+ * <audio> tag. If that is not possible, construct a cdvfile:// URL.
  */
 Entry.prototype.toURL = function () {
-    return window.location.origin.includes('file://')
-        ? this.nativeURL
-        : this.toInternalURL();
+    if (this.nativeURL) {
+        return this.nativeURL;
+    }
+    // fullPath attribute may contain the full URL in the case that
+    // toInternalURL fails.
+    return this.toInternalURL() || 'file://localhost' + this.fullPath;
 };
 
 /**

--- a/www/android/Entry.js
+++ b/www/android/Entry.js
@@ -1,0 +1,33 @@
+/*
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *
+*/
+
+module.exports = {
+  /**
+   * Return a URL that can be used to identify this entry.
+   * Use a URL that can be used to as the src attribute of a <video> or
+   * <audio> tag. If that is not possible, construct a http(s)://(localhost) URL.
+   */
+  toURL: function () {
+    return window.location.origin.includes('file://')
+        ? this.nativeURL
+        : this.toInternalURL();
+  }
+};


### PR DESCRIPTION
<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist is intended as a quick reference, for complete details please see our Contributor Guidelines:

http://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->

### Platforms affected

all

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

Recent changes to toURL should only be applied to Android

### Description
<!-- Describe your changes in detail -->

Created an Android only override and reverted original code.

### Testing
<!-- Please describe in detail how you tested your changes. -->

- cordova build
- run tests

### Checklist

- [x] I've run the tests to see all new and existing tests pass
- [ ] I added automated test coverage as appropriate for this change
- [x] Commit is prefixed with `(platform)` if this change only applies to one platform (e.g. `(android)`)
- [ ] If this Pull Request resolves an issue, I linked to the issue in the text above (and used the correct [keyword to close issues using keywords](https://help.github.com/articles/closing-issues-using-keywords/))
- [ ] I've updated the documentation if necessary
