### PR TITLE
fix(android): support cdvfile assets for custom scheme

### DIFF
--- a/tests/tests.js
+++ b/tests/tests.js
@@ -3436,6 +3436,7 @@ exports.defineAutoTests = function () {
              * which appears to be sane.
              */
             var pathExpect = cordova.platformId === 'windowsphone' ? '//nativ' : 'file://'; // eslint-disable-line no-undef
+
             if (isChrome) {
                 pathExpect = 'filesystem:http://';
             }
@@ -3805,18 +3806,22 @@ exports.defineAutoTests = function () {
             });
         });
 
-        describe('resolveLocalFileSystemURL on cdvfile://', function () {
+        describe('resolveLocalFileSystemURL for cdvfile', function () {
             it('file.spec.147 should be able to resolve cdvfile applicationDirectory fs root', function (done) {
                 var cdvfileApplicationDirectoryFsRootName;
+                var cdvfileApplicationDirectoryFsRootNameURL;
                 if (cordova.platformId === 'android') {
                     cdvfileApplicationDirectoryFsRootName = 'assets';
+                    cdvfileApplicationDirectoryFsRootNameURL = 'https://localhost/__cdvfile_' + cdvfileApplicationDirectoryFsRootName + '__/'
                 } else if (cordova.platformId === 'ios') {
                     cdvfileApplicationDirectoryFsRootName = 'bundle';
+                    cdvfileApplicationDirectoryFsRootNameURL = 'cdvfile://localhost/' + cdvfileApplicationDirectoryFsRootName + '/'
                 } else {
                     pending();
                 }
 
-                resolveLocalFileSystemURL('cdvfile://localhost/' + cdvfileApplicationDirectoryFsRootName + '/', function (applicationDirectoryRoot) {
+                resolveLocalFileSystemURL(cdvfileApplicationDirectoryFsRootNameURL, function (applicationDirectoryRoot) {
+                    console.log(applicationDirectoryRoot);
                     expect(applicationDirectoryRoot.isFile).toBe(false);
                     expect(applicationDirectoryRoot.isDirectory).toBe(true);
                     expect(applicationDirectoryRoot.name).toCanonicallyMatch('');
@@ -3825,7 +3830,7 @@ exports.defineAutoTests = function () {
 
                     // Requires HelloCordova www assets, <allow-navigation href="cdvfile:*" /> in config.xml or
                     // cdvfile: in CSP and <access origin="cdvfile://*" /> in config.xml
-                    resolveLocalFileSystemURL('cdvfile://localhost/' + cdvfileApplicationDirectoryFsRootName + '/www/img/logo.png', function (entry) {
+                    resolveLocalFileSystemURL(cdvfileApplicationDirectoryFsRootNameURL + '/www/img/logo.png', function (entry) {
                         /* eslint-enable no-undef */
                         expect(entry.isFile).toBe(true);
                         expect(entry.isDirectory).toBe(false);
@@ -3841,7 +3846,7 @@ exports.defineAutoTests = function () {
                         img.onload = function () {
                             done();
                         };
-                        img.src = entry.toInternalURL();
+                        img.src = entry.toURL();
                     }, failed.bind(null, done, 'resolveLocalFileSystemURL failed for cdvfile applicationDirectory'));
                 }, failed.bind(null, done, 'resolveLocalFileSystemURL failed for cdvfile applicationDirectory'));
             });


### PR DESCRIPTION
<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist is intended as a quick reference, for complete details please see our Contributor Guidelines:

http://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->

### Platforms affected

android

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

`cdvfile://` protocol is no longer supported and the assets file system was not working with recent changes to support the new cdvfile url pattern. 

This PR is to support the assets file sytem

### Description
<!-- Describe your changes in detail -->

Updated the `WebViewAssetLoader.PathHandler` to include `assets`

E.g. `https://localhost/__cdvfile_assets__/` will map to app's assets `/android_asset/`

### Testing
<!-- Please describe in detail how you tested your changes. -->

- cordova build
- cordova run
- test specs

### Checklist

- [x] I've run the tests to see all new and existing tests pass
- [x] I updated automated test coverage as appropriate for this change
- [x] Commit is prefixed with `(platform)` if this change only applies to one platform (e.g. `(android)`)
- [ ] If this Pull Request resolves an issue, I linked to the issue in the text above (and used the correct [keyword to close issues using keywords](https://help.github.com/articles/closing-issues-using-keywords/))
- [ ] I've updated the documentation if necessary
