### PR TITLE
test(android): fix tests to use cordova-android 10.x default https scheme

### DIFF
--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -1,6 +1,10 @@
 root: true
 extends: '@cordova/eslint-config/browser'
+globals:
+  cordova: true
 
 overrides:
-    - files: [tests/**/*.js]
-      extends: '@cordova/eslint-config/node-tests'
+  - files: [tests/**/*.js]
+    extends: '@cordova/eslint-config/node-tests'
+    globals:
+      cordova: true

--- a/tests/tests.js
+++ b/tests/tests.js
@@ -3435,9 +3435,14 @@ exports.defineAutoTests = function () {
             /* These specs verify that FileEntries have a toNativeURL method
              * which appears to be sane.
              */
-            var pathExpect = cordova.platformId === 'windowsphone' ? '//nativ' : 'file://'; // eslint-disable-line no-undef
+            var pathExpect = 'file://';
 
-            if (isChrome) {
+            if (cordova.platformId === 'android') {
+                // Starting from Cordova-Android 10.x, the app content is served from the https scheme
+                pathExpect = 'https://';
+            } else if (cordova.platformId === 'windowsphone') {
+                pathExpect = '//nativ';
+            } else if (isChrome) {
                 pathExpect = 'filesystem:http://';
             }
 


### PR DESCRIPTION
<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist is intended as a quick reference, for complete details please see our Contributor Guidelines:

http://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->

### Platforms affected

android

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

tests failing with Cordova-Android 10.x because default scheme has changed to `https`.

### Description
<!-- Describe your changes in detail -->

Update the test's default scheme to `https` for android.

### Testing
<!-- Please describe in detail how you tested your changes. -->

- test specs

### Checklist

- [x] I've run the tests to see all new and existing tests pass
- [x] I updated automated test coverage as appropriate for this change
- [x] Commit is prefixed with `(platform)` if this change only applies to one platform (e.g. `(android)`)
- [ ] If this Pull Request resolves an issue, I linked to the issue in the text above (and used the correct [keyword to close issues using keywords](https://help.github.com/articles/closing-issues-using-keywords/))
- [ ] I've updated the documentation if necessary
