### PR TITLE
fix(types): Adjust types to fix incompatibilities with TypeScript 4.4+

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -44,9 +44,9 @@ interface Window {
 /** This interface represents a file system. */
 interface FileSystem {
     /* The name of the file system, unique across the list of exposed file systems. */
-    name: string;
+    readonly name: string;
     /** The root directory of the file system. */
-    root: DirectoryEntry;
+    readonly root: FileSystemDirectoryEntry;
 }
 
 /**
@@ -55,15 +55,15 @@ interface FileSystem {
  */
 interface Entry {
     /** Entry is a file. */
-    isFile: boolean;
+    readonly isFile: boolean;
     /** Entry is a directory. */
-    isDirectory: boolean;
+    readonly isDirectory: boolean;
     /** The name of the entry, excluding the path leading to it. */
-    name: string;
+    readonly name: string;
     /** The full absolute path from the root to the entry. */
-    fullPath: string;
+    readonly fullPath: string;
     /** The file system on which the entry resides. */
-    filesystem: FileSystem;
+    readonly filesystem: FileSystem;
     nativeURL: string;
     /**
      * Look up metadata about this entry.
@@ -132,8 +132,8 @@ interface Entry {
      * @param successCallback A callback that is called with the time of the last modification.
      * @param errorCallback   A callback that is called when errors happen.
      */
-    getParent(successCallback: (entry: Entry) => void,
-        errorCallback?: (error: FileError) => void): void;
+    getParent(successCallback?: (entry: Entry) => void,
+        errorCallback?: (error: DOMException) => void): void;
 }
 
 /** This interface supplies information about the state of a file or directory. */
@@ -164,7 +164,7 @@ interface DirectoryEntry extends Entry {
      * @param errorCallback   A callback that is called when errors happen.
      */
     getFile(path: string, options?: Flags,
-        successCallback?: (entry: FileEntry) => void,
+        successCallback?: (entry: Entry) => void,
         errorCallback?: (error: FileError) => void): void;
     /**
      * Creates or looks up a directory.
@@ -180,7 +180,7 @@ interface DirectoryEntry extends Entry {
      * @param errorCallback   A callback that is called when errors happen.
      */
     getDirectory(path: string, options?: Flags,
-        successCallback?: (entry: DirectoryEntry) => void,
+        successCallback?: (entry: Entry) => void,
         errorCallback?: (error: FileError) => void): void;
     /**
      * Deletes a directory and all of its contents, if any. In the event of an error (e.g. trying
@@ -376,3 +376,7 @@ declare enum LocalFileSystem {
     PERSISTENT=1,
     TEMPORARY=0
 }
+
+// Compatibility shim to support beyond tsc4.4
+interface FileSystemDirectoryEntry extends DirectoryEntry {}
+interface FileSystemEntry extends Entry {}


### PR DESCRIPTION
### Platforms affected

Typescript type definitions only. No platform impacts.

### Motivation and Context

Changes in libdom by the TypeScript project led to conflicting definitions with this plugin. This is an attempt following on from #500 to try and address the compatibility problem.

### Description

The key point that joins libdom and this plugin together are via the `root` property
on the FileSystem interface. This results in the DirectoryEntry and Entry types needing
to align with libdom's FileSystemDirectoryEntry & FileSystemEntry.

This introduces 3 slight irregularities in order to be compatible with libdom

1. getParent successCallback needs to be optional
2. getParent errorCallback needs to be typed as a DOMException, despite it being a FileError in reality
3. getFile and getDirectory success types need to be relaxed to the base Entry

### Testing

I've created a test repository with several typescript versions, and ensured each of these compiles without issue: https://github.com/peitschie/cordova-plugin-file-type-tests

### Checklist

- [x] I've run the tests to see all new and existing tests pass
- [x] I added automated test coverage as appropriate for this change
- [x] Commit is prefixed with `(platform)` if this change only applies to one platform (e.g. `(android)`)
- [x] If this Pull Request resolves an issue, I linked to the issue in the text above (and used the correct [keyword to close issues using keywords](https://help.github.com/articles/closing-issues-using-keywords/))
- [x] I've updated the documentation if necessary
