### PR TITLE
(android) Use decoded path when querying file list in directory via assetManager

### DIFF
--- a/src/android/AssetFilesystem.java
+++ b/src/android/AssetFilesystem.java
@@ -32,6 +32,7 @@ import java.io.File;
 import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.ObjectInputStream;
+import java.net.URLDecoder;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -91,7 +92,7 @@ public class AssetFilesystem extends Filesystem {
             if (listCacheFromFile) {
                 ret = new String[0];
             } else {
-                ret = assetManager.list(assetPath);
+                ret = assetManager.list(URLDecoder.decode(assetPath, "utf-8"));
                 listCache.put(assetPath, ret);
             }
         }


### PR DESCRIPTION
### Platforms affected

Android

### Motivation and Context

The problem is that subfiles and folders cannot be listed via the assetManager.list function 
if the folder name has special characters like `@havesource`.

```
# Folder Tree
www/plugins/@havesource/
  ㄴ cordova-plugin-push
      ㄴ www
          ㄴpush.js
```

![image](https://user-images.githubusercontent.com/8110371/196867676-8b0fc851-adfe-41d6-8a38-4c2ac26acbdb.png)

### Description

The AssetManager.list function does not automatically decode the passed paths that are encoded. 
So if the folder name has special characters (such as @), it can't listing subfolders and files.

### Testing

We need to pass the decoded path to the assetManager.list function.
Then the assetManager.list function returns a list of subfolders and files successfully.

![image](https://user-images.githubusercontent.com/8110371/196868495-d9ccb5f2-2149-4d00-8485-59abe5ce1d7a.png)


### Checklist

- [ ] I've run the tests to see all new and existing tests pass
- [ ] I added automated test coverage as appropriate for this change
- [x] Commit is prefixed with `(platform)` if this change only applies to one platform (e.g. `(android)`)
- [x] If this Pull Request resolves an issue, I linked to the issue in the text above (and used the correct [keyword to close issues using keywords](https://help.github.com/articles/closing-issues-using-keywords/))
- [x I've updated the documentation if necessary
