### PR TITLE
fix(types): Mark FileWriter.write to support ArrayBuffer data

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -294,9 +294,9 @@ interface FileWriter extends FileSaver {
     length: number;
     /**
      * Write the supplied data to the file at position.
-     * @param {Blob|string} data The blob to write.
+     * @param {Blob|string|ArrayBuffer} data The blob to write.
      */
-    write(data: Blob|string): void;
+    write(data: Blob|string|ArrayBuffer): void;
     /**
      * The file position at which the next write will occur.
      * @param offset If nonnegative, an absolute byte offset into the file.


### PR DESCRIPTION
FileWriter.js clearly supports this type, and it allows memory conscious users to avoid unnecessary duplication of the memory as occurs when using a Blob.

### Platforms affected
Type-only change


### Motivation and Context
Avoid forcing unnecessary duplication of memory when attempting to write files

### Description
Clarifies `FileWriter.write` type definition to properly reflect the method's support for an `ArrayBuffer` type directly: https://github.com/apache/cordova-plugin-file/blob/c883998c011fd5b26a1643b6c65de0c6f6ed21e7/www/FileWriter.js#L156




### Testing
Type-only change. Have confirmed new type behaves correctly with code passing in an ArrayBuffer.

### Checklist

- [x] I've run the tests to see all new and existing tests pass
- [x] I added automated test coverage as appropriate for this change
- [x] Commit is prefixed with `(platform)` if this change only applies to one platform (e.g. `(android)`)
- [x] If this Pull Request resolves an issue, I linked to the issue in the text above (and used the correct [keyword to close issues using keywords](https://help.github.com/articles/closing-issues-using-keywords/))
- [x] I've updated the documentation if necessary
