### PR TITLE
feat: remove WRITE_EXTERNAL_STORAGE permission from plugin.xml

### DIFF
--- a/README.md
+++ b/README.md
@@ -269,10 +269,12 @@ Marshmallow requires the apps to ask for permissions when reading/writing to ext
 for these two directories unless external storage is not mounted. However due to a limitation, when external storage is not mounted, it would ask for
 permission to write to `cordova.file.externalApplicationStorageDirectory`.
 
-### SDK Target less than 29
+### SDK Target Less Than 29
 
 From the official [Storage updates in Android 11](https://developer.android.com/about/versions/11/privacy/storage) documentation, the [`WRITE_EXTERNAL_STORAGE`](https://developer.android.com/reference/android/Manifest.permission#WRITE_EXTERNAL_STORAGE) permission is no longer operational and does not provide access.
+
 > If this permission is not allowlisted for an app that targets an API level before [`Build.VERSION_CODES.Q`](https://developer.android.com/reference/android/os/Build.VERSION_CODES#Q) (SDK 29) this permission cannot be granted to apps.
+
 If you need to add this permission, please add the following to your `config.xml`.
 ```xml
 <config-file target="AndroidManifest.xml" parent="/*" xmlns:android="http://schemas.android.com/apk/res/android">

--- a/README.md
+++ b/README.md
@@ -269,6 +269,17 @@ Marshmallow requires the apps to ask for permissions when reading/writing to ext
 for these two directories unless external storage is not mounted. However due to a limitation, when external storage is not mounted, it would ask for
 permission to write to `cordova.file.externalApplicationStorageDirectory`.
 
+### SDK Target less than 29
+
+As the official document [Storage updates in Android 11](https://developer.android.com/about/versions/11/privacy/storage), `WRITE_EXTERNAL_STORAGE` permission no longer provide any additional access. 
+If you need to add this permission, please add followings in your `config.xml`.
+
+```xml
+    <edit-config file="AndroidManifest.xml" mode="merge" target="/manifest/uses-permission" xmlns:android="http://schemas.android.com/apk/res/android">
+            <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
+    </edit-config>    
+```
+
 ## iOS Quirks
 
 - `cordova.file.applicationStorageDirectory` is read-only; attempting to store

--- a/README.md
+++ b/README.md
@@ -276,6 +276,7 @@ From the official [Storage updates in Android 11](https://developer.android.com/
 > If this permission is not allowlisted for an app that targets an API level before [`Build.VERSION_CODES.Q`](https://developer.android.com/reference/android/os/Build.VERSION_CODES#Q) (SDK 29) this permission cannot be granted to apps.
 
 If you need to add this permission, please add the following to your `config.xml`.
+
 ```xml
 <config-file target="AndroidManifest.xml" parent="/*" xmlns:android="http://schemas.android.com/apk/res/android">
     <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" android:maxSdkVersion="28" />

--- a/README.md
+++ b/README.md
@@ -271,13 +271,13 @@ permission to write to `cordova.file.externalApplicationStorageDirectory`.
 
 ### SDK Target less than 29
 
-As the official document [Storage updates in Android 11](https://developer.android.com/about/versions/11/privacy/storage), `WRITE_EXTERNAL_STORAGE` permission no longer provide any additional access. 
-If you need to add this permission, please add followings in your `config.xml`.
-
+From the official [Storage updates in Android 11](https://developer.android.com/about/versions/11/privacy/storage) documentation, the [`WRITE_EXTERNAL_STORAGE`](https://developer.android.com/reference/android/Manifest.permission#WRITE_EXTERNAL_STORAGE) permission is no longer operational and does not provide access.
+> If this permission is not allowlisted for an app that targets an API level before [`Build.VERSION_CODES.Q`](https://developer.android.com/reference/android/os/Build.VERSION_CODES#Q) (SDK 29) this permission cannot be granted to apps.
+If you need to add this permission, please add the following to your `config.xml`.
 ```xml
-    <edit-config file="AndroidManifest.xml" mode="merge" target="/manifest/uses-permission" xmlns:android="http://schemas.android.com/apk/res/android">
-            <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
-    </edit-config>    
+<config-file target="AndroidManifest.xml" parent="/*" xmlns:android="http://schemas.android.com/apk/res/android">
+    <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" android:maxSdkVersion="28" />
+</config-file>
 ```
 
 ## iOS Quirks

--- a/plugin.xml
+++ b/plugin.xml
@@ -132,9 +132,6 @@ to config.xml in order for the application to find previously stored files.
             </feature>
             <allow-navigation href="cdvfile:*" />
         </config-file>
-        <config-file target="AndroidManifest.xml" parent="/*">
-            <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
-        </config-file>
 
         <source-file src="src/android/EncodingException.java" target-dir="src/org/apache/cordova/file" />
         <source-file src="src/android/FileExistsException.java" target-dir="src/org/apache/cordova/file" />


### PR DESCRIPTION
### Platforms affected

Android

### Motivation and Context

`WRITE_EXTERNAL_STORAGE` permission brings build error at Android SDK 33.

closes #543
closes https://github.com/apache/cordova-plugin-file/issues/243

### Description

Remove `WRITE_EXTERNAL_STORAGE` from `plugin.xml`.

### Testing

Exec Local test with cordova-paramedic.
All tests passed with Pixel 5 API 30 and Pixel 5 API 33. 

### Checklist

- [x] I've run the tests to see all new and existing tests pass
- [ ] I added automated test coverage as appropriate for this change
- [x] Commit is prefixed with `(platform)` if this change only applies to one platform (e.g. `(android)`)
- [ ] If this Pull Request resolves an issue, I linked to the issue in the text above (and used the correct [keyword to close issues using keywords](https://help.github.com/articles/closing-issues-using-keywords/))
- [x] I've updated the documentation if necessary
