### PR TITLE
fix(android): Request permission Android <= 10 on API 33

### DIFF
--- a/src/android/FileUtils.java
+++ b/src/android/FileUtils.java
@@ -487,23 +487,18 @@ public class FileUtils extends CordovaPlugin {
                     String dirname = args.getString(0);
                     String path = args.getString(1);
 
-                    if (dirname.contains(LocalFilesystemURL.CDVFILE_KEYWORD) == true) {
+                    String nativeURL = resolveLocalFileSystemURI(dirname).getString("nativeURL");
+                    boolean containsCreate = (args.isNull(2)) ? false : args.getJSONObject(2).optBoolean("create", false);
+
+                    if(containsCreate && needPermission(nativeURL, WRITE)) {
+                        getWritePermission(rawArgs, ACTION_GET_FILE, callbackContext);
+                    }
+                    else if(!containsCreate && needPermission(nativeURL, READ)) {
+                        getReadPermission(rawArgs, ACTION_GET_FILE, callbackContext);
+                    }
+                    else {
                         JSONObject obj = getFile(dirname, path, args.optJSONObject(2), false);
                         callbackContext.success(obj);
-                    } else {
-                        String nativeURL = resolveLocalFileSystemURI(dirname).getString("nativeURL");
-                        boolean containsCreate = (args.isNull(2)) ? false : args.getJSONObject(2).optBoolean("create", false);
-
-                        if(containsCreate && needPermission(nativeURL, WRITE)) {
-                            getWritePermission(rawArgs, ACTION_GET_FILE, callbackContext);
-                        }
-                        else if(!containsCreate && needPermission(nativeURL, READ)) {
-                            getReadPermission(rawArgs, ACTION_GET_FILE, callbackContext);
-                        }
-                        else {
-                            JSONObject obj = getFile(dirname, path, args.optJSONObject(2), false);
-                            callbackContext.success(obj);
-                        }
                     }
                 }
             }, rawArgs, callbackContext);


### PR DESCRIPTION
<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist is intended as a quick reference, for complete details please see our Contributor Guidelines:

http://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->

### Platforms affected



### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
On Android 10 and below, on cordova-plugin-file V8 and cordova-android V12 the permission request was not displayed to the user witch lead to an error when trying to write a file in the externalRootDirectory + '/Download' folder.

<!-- If it fixes an open issue, please link to the issue here. -->
[Permission not requested on Android 10 when targeting API 33 (#586)](https://github.com/apache/cordova-plugin-file/issues/586)


### Description
<!-- Describe your changes in detail -->
This fix always ask for permission if needed on GetFile action. This allow to fix the bug.


### Testing
<!-- Please describe in detail how you tested your changes. -->
I test on Android 10/11/12/13 that writing a file to externalRootDirectory + '/Download' works.


### Checklist

- [x] I've run the tests to see all new and existing tests pass
- [ ] I added automated test coverage as appropriate for this change
- [x] Commit is prefixed with `(platform)` if this change only applies to one platform (e.g. `(android)`)
- [x] If this Pull Request resolves an issue, I linked to the issue in the text above (and used the correct [keyword to close issues using keywords](https://help.github.com/articles/closing-issues-using-keywords/))
- [ ] I've updated the documentation if necessary
