### PR TITLE
feat(android): allow read-write to app dirs on external sdcards too

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,7 +156,7 @@ the `cordova.file.*` properties map to physical paths on a real device.
 | Device Path                                     | `cordova.file.*`            | `AndroidExtraFileSystems` | r/w? | persistent? | OS clears | private |
 |:------------------------------------------------|:----------------------------|:--------------------------|:----:|:-----------:|:---------:|:-------:|
 | `file:///android_asset/`                        | applicationDirectory        | assets                    | r    |     N/A     |     N/A   |   Yes   |
-| `/data/data/<app-id>/`                          | applicationStorageDirectory | -                         | r/w  |     N/A     |     N/A   |   Yes   |
+| `<internal>/Android/data/<app-id>/`             | applicationStorageDirectory | -                         | r/w  |     N/A     |     N/A   |   Yes   |
 | &nbsp;&nbsp;&nbsp;`cache`                       | cacheDirectory              | cache                     | r/w  |     Yes     |     Yes\* |   Yes   |
 | &nbsp;&nbsp;&nbsp;`files`                       | dataDirectory               | files                     | r/w  |     Yes     |     No    |   Yes   |
 | &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;`Documents` |                             | documents                 | r/w  |     Yes     |     No    |   Yes   |

--- a/src/android/FileUtils.java
+++ b/src/android/FileUtils.java
@@ -625,6 +625,9 @@ public class FileUtils extends CordovaPlugin {
         if(j.has("externalApplicationStorageDirectory")) {
             allowedStorageDirectories.add(j.getString("externalApplicationStorageDirectory"));
         }
+        ArrayList<String> allowedExtraPatternStorageDirectories = new ArrayList<String>();
+        // basic pattern for usual application storage directory, to extend the allowed list to external SD cards for example
+        allowedExtraPatternStorageDirectories.add("/Android/data/" + cordova.getActivity().getPackageName() + "/");
 
         if(permissionType == READ && hasReadPermission()) {
             return false;
@@ -636,6 +639,11 @@ public class FileUtils extends CordovaPlugin {
         // Permission required if the native url lies outside the allowed storage directories
         for(String directory : allowedStorageDirectories) {
             if(nativeURL.startsWith(directory)) {
+                return false;
+            }
+        }
+        for (String extraPatternDirectory : allowedExtraPatternStorageDirectories) {
+            if (nativeURL.contains(extraPatternDirectory)) {
                 return false;
             }
         }


### PR DESCRIPTION
<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist is intended as a quick reference, for complete details please see our Contributor Guidelines:

http://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->

### Platforms affected
Android


### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
Reading and writing to app dirs onto external SD cards works fine without any permission.


### Description
<!-- Describe your changes in detail -->
Reading and writing to app dirs onto external SD cards is currently asking for permissions, `*_EXTERNAL_STORAGE` or more recently `READ_MEDIA_*`.
The SDK 33 permission change made me look more into this, as asking for _MEDIA_ related permissions seems strange.
With this PR, app dirs on external SD cards are excluded from this requirement ; even if _browsing_ among directories, some of which are still outside of the allowed list, continue to ask for sort of unrelated permissions most of the time I think. While it may indeed be useful if the target files really are "media".


### Testing
<!-- Please describe in detail how you tested your changes. -->
Built a testApp with targetSDK 33, installed on emulators API 28, 29, 30, 32, and 33,
Then I checked both READ and WRITE inside app dirs of internal, external, and external sd cards storage paths: operations run fine, and without asking for any permission.
Similar operations but for files outside of the allowed list still require permissions.



### Checklist

- [ ] I've run the tests to see all new and existing tests pass
- [ ] I added automated test coverage as appropriate for this change
- [x] Commit is prefixed with `(platform)` if this change only applies to one platform (e.g. `(android)`)
- [ ] If this Pull Request resolves an issue, I linked to the issue in the text above (and used the correct [keyword to close issues using keywords](https://help.github.com/articles/closing-issues-using-keywords/))
- [x] I've updated the documentation if necessary
