### PR TITLE
Android: replace deprecated StatFs functions

### DIFF
--- a/src/android/DirectoryManager.java
+++ b/src/android/DirectoryManager.java
@@ -84,9 +84,7 @@ public class DirectoryManager {
     public static long getFreeSpaceInBytes(String path) {
         try {
             StatFs stat = new StatFs(path);
-            long blockSize = stat.getBlockSize();
-            long availableBlocks = stat.getAvailableBlocks();
-            return availableBlocks * blockSize;
+            return stat.getAvailableBytes();
         } catch (IllegalArgumentException e) {
             // The path was invalid. Just return 0 free bytes.
             return 0;


### PR DESCRIPTION
<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist is intended as a quick reference, for complete details please see our Contributor Guidelines:

http://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->

### Platforms affected
Android


### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
[`getAvailableBlocks`](https://developer.android.com/reference/android/os/StatFs#getAvailableBlocks()) and [`getBlockSize`](https://developer.android.com/reference/android/os/StatFs#getBlockSize()) are deprecated since API 18


### Description
<!-- Describe your changes in detail -->
[`getAvailableBytes`](https://developer.android.com/reference/android/os/StatFs#getAvailableBytes()) is available since API 18
while current `cordova-android` must be [`>=12.0.0`](https://github.com/apache/cordova-plugin-file/blob/master/plugin.xml#L33), so [minSdk 24](https://github.com/apache/cordova-android/blob/rel/12.0.0/framework/cdv-gradle-config-defaults.json#L2)


### Testing
<!-- Please describe in detail how you tested your changes. -->



### Checklist

- [x] I've run the tests to see all new and existing tests pass
- [x] I added automated test coverage as appropriate for this change
- [x] Commit is prefixed with `(platform)` if this change only applies to one platform (e.g. `(android)`)
- [x] If this Pull Request resolves an issue, I linked to the issue in the text above (and used the correct [keyword to close issues using keywords](https://help.github.com/articles/closing-issues-using-keywords/))
- [x] I've updated the documentation if necessary
