### PR TITLE
fix(android): hasWritePermission for SDK 33

### DIFF
--- a/src/android/FileUtils.java
+++ b/src/android/FileUtils.java
@@ -543,11 +543,8 @@ public class FileUtils extends CordovaPlugin {
     }
 
     private void getWritePermission(String rawArgs, int action, CallbackContext callbackContext) {
- 	int requestCode = pendingRequests.createRequest(rawArgs, action, callbackContext);
-        if (android.os.Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
-        } else {
-          PermissionHelper.requestPermission(this, requestCode, Manifest.permission.WRITE_EXTERNAL_STORAGE);
-        }
+        int requestCode = pendingRequests.createRequest(rawArgs, action, callbackContext);
+        PermissionHelper.requestPermission(this, requestCode, Manifest.permission.WRITE_EXTERNAL_STORAGE);
     }
 
     /**

--- a/src/android/FileUtils.java
+++ b/src/android/FileUtils.java
@@ -567,11 +567,9 @@ public class FileUtils extends CordovaPlugin {
     }
 
     private boolean hasWritePermission() {
-          if (android.os.Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
-                return true;
-              } else {
-                return PermissionHelper.hasPermission(this, Manifest.permission.WRITE_EXTERNAL_STORAGE);
-              }
+        return android.os.Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU
+            ? true
+            : PermissionHelper.hasPermission(this, Manifest.permission.WRITE_EXTERNAL_STORAGE);
     }
 
     private boolean needPermission(String nativeURL, int permissionType) throws JSONException {

--- a/src/android/FileUtils.java
+++ b/src/android/FileUtils.java
@@ -569,8 +569,8 @@ public class FileUtils extends CordovaPlugin {
     private boolean hasWritePermission() {
         // Starting with API 33, requesting WRITE_EXTERNAL_STORAGE is an auto permission rejection
         return android.os.Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU
-            ? true
-            : PermissionHelper.hasPermission(this, Manifest.permission.WRITE_EXTERNAL_STORAGE);
+                ? true
+                : PermissionHelper.hasPermission(this, Manifest.permission.WRITE_EXTERNAL_STORAGE);
     }
 
     private boolean needPermission(String nativeURL, int permissionType) throws JSONException {

--- a/src/android/FileUtils.java
+++ b/src/android/FileUtils.java
@@ -567,6 +567,7 @@ public class FileUtils extends CordovaPlugin {
     }
 
     private boolean hasWritePermission() {
+        // Starting with API 33, requesting WRITE_EXTERNAL_STORAGE is an auto permission rejection
         return android.os.Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU
             ? true
             : PermissionHelper.hasPermission(this, Manifest.permission.WRITE_EXTERNAL_STORAGE);

--- a/src/android/FileUtils.java
+++ b/src/android/FileUtils.java
@@ -543,11 +543,11 @@ public class FileUtils extends CordovaPlugin {
     }
 
     private void getWritePermission(String rawArgs, int action, CallbackContext callbackContext) {
- int requestCode = pendingRequests.createRequest(rawArgs, action, callbackContext);
+ 	int requestCode = pendingRequests.createRequest(rawArgs, action, callbackContext);
         if (android.os.Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
-          } else {
-        PermissionHelper.requestPermission(this, requestCode, Manifest.permission.WRITE_EXTERNAL_STORAGE);
-          }
+        } else {
+          PermissionHelper.requestPermission(this, requestCode, Manifest.permission.WRITE_EXTERNAL_STORAGE);
+        }
     }
 
     /**

--- a/src/android/FileUtils.java
+++ b/src/android/FileUtils.java
@@ -543,8 +543,10 @@ public class FileUtils extends CordovaPlugin {
     }
 
     private void getWritePermission(String rawArgs, int action, CallbackContext callbackContext) {
-        int requestCode = pendingRequests.createRequest(rawArgs, action, callbackContext);
-        PermissionHelper.requestPermission(this, requestCode, Manifest.permission.WRITE_EXTERNAL_STORAGE);
+        if (android.os.Build.VERSION.SDK_INT < Build.VERSION_CODES.TIRAMISU) {
+            int requestCode = pendingRequests.createRequest(rawArgs, action, callbackContext);
+            PermissionHelper.requestPermission(this, requestCode, Manifest.permission.WRITE_EXTERNAL_STORAGE);
+        }
     }
 
     /**

--- a/src/android/FileUtils.java
+++ b/src/android/FileUtils.java
@@ -543,8 +543,11 @@ public class FileUtils extends CordovaPlugin {
     }
 
     private void getWritePermission(String rawArgs, int action, CallbackContext callbackContext) {
-        int requestCode = pendingRequests.createRequest(rawArgs, action, callbackContext);
+ int requestCode = pendingRequests.createRequest(rawArgs, action, callbackContext);
+        if (android.os.Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+          } else {
         PermissionHelper.requestPermission(this, requestCode, Manifest.permission.WRITE_EXTERNAL_STORAGE);
+          }
     }
 
     /**
@@ -567,7 +570,11 @@ public class FileUtils extends CordovaPlugin {
     }
 
     private boolean hasWritePermission() {
-        return PermissionHelper.hasPermission(this, Manifest.permission.WRITE_EXTERNAL_STORAGE);
+          if (android.os.Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+                return true;
+              } else {
+                return PermissionHelper.hasPermission(this, Manifest.permission.WRITE_EXTERNAL_STORAGE);
+              }
     }
 
     private boolean needPermission(String nativeURL, int permissionType) throws JSONException {


### PR DESCRIPTION
<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist is intended as a quick reference, for complete details please see our Contributor Guidelines:

http://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->

### Platforms affected

android

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

rebase, fix, and simplify changes from #581

Closes #581

### Description
<!-- Describe your changes in detail -->

This PR performed following changes against #581:

- Rebased against current main branch
- Reverted previous changes to `getWritePermission` but applied suggestion to simplify. the condition check and to add extra accidental calls, even though the method would never be called in that scenario.
-  Simplifed `hasWritePermission` logic
- Added comment suggestion to `hasWritePermission`

### Testing
<!-- Please describe in detail how you tested your changes. -->

`build test`

### Checklist

- [ ] I've run the tests to see all new and existing tests pass
- [ ] I added automated test coverage as appropriate for this change
- [ ] Commit is prefixed with `(platform)` if this change only applies to one platform (e.g. `(android)`)
- [ ] If this Pull Request resolves an issue, I linked to the issue in the text above (and used the correct [keyword to close issues using keywords](https://help.github.com/articles/closing-issues-using-keywords/))
- [ ] I've updated the documentation if necessary
