### PR TITLE
Android : Added write permission check for Android devices of platfor…

### DIFF
--- a/src/android/FileUtils.java
+++ b/src/android/FileUtils.java
@@ -547,6 +547,14 @@ public class FileUtils extends CordovaPlugin {
             int requestCode = pendingRequests.createRequest(rawArgs, action, callbackContext);
             PermissionHelper.requestPermission(this, requestCode, Manifest.permission.WRITE_EXTERNAL_STORAGE);
         }
+        else {
+            PermissionHelper.requestPermissions(this, requestCode, 
+            new String[] {
+                Manifest.permission.READ_MEDIA_IMAGES,
+                Manifest.permission.READ_MEDIA_VIDEO,
+                Manifest.permission.READ_MEDIA_AUDIO
+            });
+        }
     }
 
     /**


### PR DESCRIPTION
### Platforms affected

Android

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

When writing a file on Android devices where version is >= 13 getting false as permission while checking runtime write permission. 


### Description
<!-- Describe your changes in detail -->

On Android devices >= 13 the write permission has not been checked and it always returns as false. This is happening in FileUtils.java file in getWritePermission method.

The same issue also has been raised and it this pull request will solve that

https://github.com/apache/cordova-plugin-file/issues/610


### Testing
<!-- Please describe in detail how you tested your changes. -->

Tested the code on real devices where android versions are 11, 12, and 13 respectively. Able to write files now.

### Checklist

- [x] I've run the tests to see all new and existing tests pass
- [ ] I added automated test coverage as appropriate for this change
- [x] Commit is prefixed with `(platform)` if this change only applies to one platform (e.g. `(android)`)
- [x] If this Pull Request resolves an issue, I linked to the issue in the text above (and used the correct [keyword to close issues using keywords](https://help.github.com/articles/closing-issues-using-keywords/))
- [ ] I've updated the documentation if necessary
