### PR TITLE
Android: restore getWritePermission, but check can have permission

### DIFF
--- a/src/android/FileUtils.java
+++ b/src/android/FileUtils.java
@@ -543,10 +543,8 @@ public class FileUtils extends CordovaPlugin {
     }
 
     private void getWritePermission(String rawArgs, int action, CallbackContext callbackContext) {
-        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.TIRAMISU) {
-            int requestCode = pendingRequests.createRequest(rawArgs, action, callbackContext);
-            PermissionHelper.requestPermission(this, requestCode, Manifest.permission.WRITE_EXTERNAL_STORAGE);
-        }
+        int requestCode = pendingRequests.createRequest(rawArgs, action, callbackContext);
+        PermissionHelper.requestPermission(this, requestCode, Manifest.permission.WRITE_EXTERNAL_STORAGE);
     }
 
     /**
@@ -568,11 +566,21 @@ public class FileUtils extends CordovaPlugin {
         }
     }
 
+    private boolean canHaveReadPermission() {
+        return true;
+    }
+
+    /**
+     * Starting with API 33, requesting WRITE_EXTERNAL_STORAGE is an auto permission rejection.
+     *
+     * @return
+     */
     private boolean hasWritePermission() {
-        // Starting with API 33, requesting WRITE_EXTERNAL_STORAGE is an auto permission rejection
-        return Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU
-                ? true
-                : PermissionHelper.hasPermission(this, Manifest.permission.WRITE_EXTERNAL_STORAGE);
+        return PermissionHelper.hasPermission(this, Manifest.permission.WRITE_EXTERNAL_STORAGE);
+    }
+
+    private boolean canHaveWritePermission() {
+        return Build.VERSION.SDK_INT < Build.VERSION_CODES.TIRAMISU;
     }
 
     private boolean needPermission(String nativeURL, int permissionType) throws JSONException {
@@ -584,9 +592,9 @@ public class FileUtils extends CordovaPlugin {
             allowedStorageDirectories.add(j.getString("externalApplicationStorageDirectory"));
         }
 
-        if (permissionType == READ && hasReadPermission()) {
+        if (permissionType == READ && (!canHaveReadPermission() || hasReadPermission())) {
             return false;
-        } else if (permissionType == WRITE && hasWritePermission()) {
+        } else if (permissionType == WRITE && (!canHaveWritePermission() || hasWritePermission())) {
             return false;
         }
 

--- a/src/android/FileUtils.java
+++ b/src/android/FileUtils.java
@@ -534,7 +534,7 @@ public class FileUtils extends CordovaPlugin {
 
     private void getReadPermission(String rawArgs, int action, CallbackContext callbackContext) {
         int requestCode = pendingRequests.createRequest(rawArgs, action, callbackContext);
-        if (android.os.Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
             PermissionHelper.requestPermissions(this, requestCode,
                     new String[]{Manifest.permission.READ_MEDIA_IMAGES, Manifest.permission.READ_MEDIA_VIDEO, Manifest.permission.READ_MEDIA_AUDIO});
         } else {
@@ -543,7 +543,7 @@ public class FileUtils extends CordovaPlugin {
     }
 
     private void getWritePermission(String rawArgs, int action, CallbackContext callbackContext) {
-        if (android.os.Build.VERSION.SDK_INT < Build.VERSION_CODES.TIRAMISU) {
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.TIRAMISU) {
             int requestCode = pendingRequests.createRequest(rawArgs, action, callbackContext);
             PermissionHelper.requestPermission(this, requestCode, Manifest.permission.WRITE_EXTERNAL_STORAGE);
         }
@@ -559,7 +559,7 @@ public class FileUtils extends CordovaPlugin {
      * @return
      */
     private boolean hasReadPermission() {
-        if (android.os.Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
             return PermissionHelper.hasPermission(this, Manifest.permission.READ_MEDIA_IMAGES)
                     && PermissionHelper.hasPermission(this, Manifest.permission.READ_MEDIA_VIDEO)
                     && PermissionHelper.hasPermission(this, Manifest.permission.READ_MEDIA_AUDIO);
@@ -570,7 +570,7 @@ public class FileUtils extends CordovaPlugin {
 
     private boolean hasWritePermission() {
         // Starting with API 33, requesting WRITE_EXTERNAL_STORAGE is an auto permission rejection
-        return android.os.Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU
+        return Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU
                 ? true
                 : PermissionHelper.hasPermission(this, Manifest.permission.WRITE_EXTERNAL_STORAGE);
     }


### PR DESCRIPTION
<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist is intended as a quick reference, for complete details please see our Contributor Guidelines:

http://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->

### Platforms affected
Android


### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
Follow-up to #608 and my comment with [question and analysis on it](https://github.com/apache/cordova-plugin-file/pull/608#pullrequestreview-1795612967).


### Description
<!-- Describe your changes in detail -->
Revert `getWritePermission` to have consistent code for it.
And make it never been called, not through a wrong return value of `true` inside `hasWritePermission`, but with a dedicated `canHaveWritePermission` function. This one is the place to compare current version with API 33.


### Testing
<!-- Please describe in detail how you tested your changes. -->



### Checklist

- [x] I've run the tests to see all new and existing tests pass
- [x] I added automated test coverage as appropriate for this change
- [x] Commit is prefixed with `(platform)` if this change only applies to one platform (e.g. `(android)`)
- [x] If this Pull Request resolves an issue, I linked to the issue in the text above (and used the correct [keyword to close issues using keywords](https://help.github.com/articles/closing-issues-using-keywords/))
- [x] I've updated the documentation if necessary
