### PR TITLE
feat(ios): add bundled resources for privacy manifest

### DIFF
--- a/README.md
+++ b/README.md
@@ -880,3 +880,17 @@ function createDirectory(rootDirEntry) {
 ```
 
 When creating subfolders, you need to create each folder separately as shown in the preceding code.
+
+---
+
+## iOS Privacy Manifest
+
+As of May 1, 2024, Apple requires a privacy manifest file to be created for apps and third-party SDKs. The purpose of the privacy manifest file is to explain the data being collected and the reasons for the required APIs it uses. Starting with `cordova-ios@7.1.0`, APIs are available for configuring the privacy manifest file from `config.xml`.
+
+This plugin comes pre-bundled with a `PrivacyInfo.xcprivacy` file that contains the list of APIs it uses and the reasons for using them.
+
+However, as an app developer, it will be your responsibility to identify additional information explaining what your app does with that data.
+
+In this case, you will need to review the "[Describing data use in privacy manifests](https://developer.apple.com/documentation/bundleresources/privacy_manifest_files/describing_data_use_in_privacy_manifests)" to understand the list of known `NSPrivacyCollectedDataTypes` and `NSPrivacyCollectedDataTypePurposes`.
+
+Also, ensure all four keys—`NSPrivacyTracking`, `NSPrivacyTrackingDomains`, `NSPrivacyAccessedAPITypes`, and `NSPrivacyCollectedDataTypes`—are defined, even if you are not making an addition to the other items. Apple requires all to be defined.

--- a/plugin.xml
+++ b/plugin.xml
@@ -197,6 +197,8 @@ to config.xml in order for the application to find previously stored files.
 
         <framework src="AssetsLibrary.framework" />
         <framework src="MobileCoreServices.framework" />
+
+        <resource-file src="src/ios/CDVFile.bundle" target="CDVFile.bundle" />
     </platform>
 
     <!-- osx -->

--- a/src/ios/CDVFile.bundle/PrivacyInfo.xcprivacy
+++ b/src/ios/CDVFile.bundle/PrivacyInfo.xcprivacy
@@ -39,7 +39,7 @@
 			<string>NSPrivacyAccessedAPICategoryFileTimestamp</string>
 			<key>NSPrivacyAccessedAPITypeReasons</key>
 			<array>
-				<string>DDA9.1</string>
+				<string>C617.1</string>
 			</array>
 		</dict>
 	</array>

--- a/src/ios/CDVFile.bundle/PrivacyInfo.xcprivacy
+++ b/src/ios/CDVFile.bundle/PrivacyInfo.xcprivacy
@@ -1,0 +1,49 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+	Licensed to the Apache Software Foundation (ASF) under one
+	or more contributor license agreements.  See the NOTICE file
+	distributed with this work for additional information
+	regarding copyright ownership.  The ASF licenses this file
+	to you under the Apache License, Version 2.0 (the
+	"License"); you may not use this file except in compliance
+	with the License.  You may obtain a copy of the License at
+
+		http://www.apache.org/licenses/LICENSE-2.0
+
+	Unless required by applicable law or agreed to in writing,
+	software distributed under the License is distributed on an
+	"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+	KIND, either express or implied.  See the License for the
+	specific language governing permissions and limitations
+	under the License.
+-->
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>NSPrivacyTracking</key>
+	<false/>
+	<key>NSPrivacyTrackingDomains</key>
+	<array/>
+	<key>NSPrivacyAccessedAPITypes</key>
+	<array>
+		<dict>
+			<key>NSPrivacyAccessedAPIType</key>
+			<string>NSPrivacyAccessedAPICategoryDiskSpace</string>
+			<key>NSPrivacyAccessedAPITypeReasons</key>
+			<array>
+				<string>E174.1</string>
+			</array>
+		</dict>
+		<dict>
+			<key>NSPrivacyAccessedAPIType</key>
+			<string>NSPrivacyAccessedAPICategoryFileTimestamp</string>
+			<key>NSPrivacyAccessedAPITypeReasons</key>
+			<array>
+				<string>DDA9.1</string>
+			</array>
+		</dict>
+	</array>
+	<key>NSPrivacyCollectedDataTypes</key>
+	<array/>
+</dict>
+</plist>


### PR DESCRIPTION
<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist is intended as a quick reference, for complete details please see our Contributor Guidelines:

http://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->

### Platforms affected

ios

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

Support Apple's Privacy Manifest requirements

closes https://github.com/apache/cordova-plugin-file/issues/620

### Description
<!-- Describe your changes in detail -->

- Created a resource bundle
- Added `PrivacyInfo.xcprivacy` to the resource bundle
- Load bundle into iOS project with `resource-file` in `plugin.xml`

The bundle is prefixed with Cordova's internal `CDV` namespace. 

Note for third-party plugins: When creating a bundle or even class names, it is recommended to establish your own namespace and utilize a unique identifier to prevent conflicts with other plugins.

### Testing
<!-- Please describe in detail how you tested your changes. -->

- platform add
- plugin add
- archive project
- generated privacy report

### Checklist

- [x] I've run the tests to see all new and existing tests pass
- [ ] I added automated test coverage as appropriate for this change
- [x] Commit is prefixed with `(platform)` if this change only applies to one platform (e.g. `(android)`)
- [x] If this Pull Request resolves an issue, I linked to the issue in the text above (and used the correct [keyword to close issues using keywords](https://help.github.com/articles/closing-issues-using-keywords/))
- [ ] I've updated the documentation if necessary
