### PR TITLE
fix(android): Content FS support in PathHandler

### DIFF
--- a/src/android/FileUtils.java
+++ b/src/android/FileUtils.java
@@ -1310,10 +1310,20 @@ public class FileUtils extends CordovaPlugin {
                         }
 
                         Uri fileUri = Uri.parse(fileTarget);
+                        String mimeType = null;
 
                         try {
-                            CordovaResourceApi.OpenForReadResult resource = resourceApi.openForRead(fileUri);
-                            return new WebResourceResponse(resource.mimeType, null, resource.inputStream);
+                            InputStream io = null;
+                            if (isAssetsFS) {
+                                io = webView.getContext().getAssets().open(fileTarget);
+                                mimeType = getMimeType(fileUri);
+                            } else {
+                                CordovaResourceApi.OpenForReadResult resource = resourceApi.openForRead(fileUri);
+                                io = resource.inputStream;
+                                mimeType = resource.mimeType;
+                            }
+
+                            return new WebResourceResponse(mimeType, null, io);
                         } catch (FileNotFoundException e) {
                             Log.e(LOG_TAG, e.getMessage());
                         } catch (IOException e) {


### PR DESCRIPTION
<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist is intended as a quick reference, for complete details please see our Contributor Guidelines:

http://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->

### Platforms affected

Android

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

Improves support for the webview asset loader Path handling for easier DOM access,
especially for `content://` urls.

### Description
<!-- Describe your changes in detail -->

There are 3 main changes:

1. Assets filesystem check is unsafe

`targetFileSystem == "assets";`

does not do what might have been expected, the condition will always yield false.
This is because in Java, comparing an object to a string literal using a `==` operator is a reference equality check. That is it's not testing if the values are equal, it's testing if they are the *same* object. Because a string literal is always making a new object to evaluate this line, it will always be false.

This was corrected to use `.equals` which does a value equality check.

2. Support `content` filesystem.

The existing path handler supported many different filesystems, but `content` was missing. Adding support for the content filesystem required a few other changes.

Including:
 - Adding the mapping
 - Parsing path segments (which is a decoded form) and re-encoding them for content paths. This is important because the content path must be rebuilt exactly how the Android OS originally produced it, otherwise it will produce permission issues.
 - Replacing raw file API usage with CordovaResourceApi which intelligently checks for the uri type and calls the appropriate API to handle reading the resource.

### Testing
<!-- Please describe in detail how you tested your changes. -->

Ran `npm test`.

~Paramedic tests isn't running locally and I'm not sure why, so we'll see if it runs on the CI.~

I also have a test project that I used to test this change specifically:

[cameraTest.zip](https://github.com/user-attachments/files/16288199/cameraTest.zip)

Note: The camera plugin was tested with https://github.com/apache/cordova-plugin-camera/pull/889 PR.

Note: The failing iOS change is not a regression of this PR, as can be observed it was failing on the [8.1 release](https://github.com/apache/cordova-plugin-file/actions/runs/9385708770). Not sure when that test started failing.

### Checklist

- [x] I've run the tests to see all new and existing tests pass
- [ ] I added automated test coverage as appropriate for this change
- [x] Commit is prefixed with `(platform)` if this change only applies to one platform (e.g. `(android)`)
- [x] If this Pull Request resolves an issue, I linked to the issue in the text above (and used the correct [keyword to close issues using keywords](https://help.github.com/articles/closing-issues-using-keywords/))
- [x] I've updated the documentation if necessary
