### PR TITLE
README.md: Correct onwriteend to onwrite

### DIFF
--- a/README.md
+++ b/README.md
@@ -639,7 +639,7 @@ function writeFile(fileEntry, dataObj) {
     // Create a FileWriter object for our FileEntry (log.txt).
     fileEntry.createWriter(function (fileWriter) {
 
-        fileWriter.onwriteend = function() {
+        fileWriter.onwrite = function() {
             console.log("Successful file write...");
             readFile(fileEntry);
         };
@@ -703,13 +703,13 @@ function writeFile(fileEntry, dataObj, isAppend) {
     // Create a FileWriter object for our FileEntry (log.txt).
     fileEntry.createWriter(function (fileWriter) {
 
-        fileWriter.onwriteend = function() {
-            console.log("Successful file read...");
+        fileWriter.onwrite = function() {
+            console.log("Successful file write...");
             readFile(fileEntry);
         };
 
         fileWriter.onerror = function (e) {
-            console.log("Failed file read: " + e.toString());
+            console.log("Failed file write: " + e.toString());
         };
 
         // If we are appending data to file, go to the end of the file.
@@ -783,7 +783,7 @@ function writeFile(fileEntry, dataObj, isAppend) {
     // Create a FileWriter object for our FileEntry (log.txt).
     fileEntry.createWriter(function (fileWriter) {
 
-        fileWriter.onwriteend = function() {
+        fileWriter.onwrite = function() {
             console.log("Successful file write...");
             if (dataObj.type == "image/png") {
                 readBinaryFile(fileEntry);


### PR DESCRIPTION
1. The `onwriteend` samples are wrong. The correct callback is `onwrite` for sucessful writes, as you can see here:

### onwrite

https://github.com/apache/cordova-plugin-file/blob/92caa81b724019b9cc63fba7a0838b69ea6312d2/www/FileWriter.js#L62-L63

### onwriteend

https://github.com/apache/cordova-plugin-file/blob/92caa81b724019b9cc63fba7a0838b69ea6312d2/www/FileWriter.js#L65-L66

2. Corrected console.log-messages in `onwrite` and `onerror`, where it mistakenly says "Successful file **read**..." instead of "**write**"