### PR TITLE
fix(android): Regression breaking resolved DOM-usable file:// paths

### DIFF
--- a/src/android/FileUtils.java
+++ b/src/android/FileUtils.java
@@ -1318,6 +1318,9 @@ public class FileUtils extends CordovaPlugin {
                                 io = webView.getContext().getAssets().open(fileTarget);
                                 mimeType = getMimeType(fileUri);
                             } else {
+                                if (fileUri.getScheme() == null) {
+                                    fileUri = Uri.parse(fileSystem.rootUri.getScheme() + "://" + fileUri.getPath());
+                                }
                                 CordovaResourceApi.OpenForReadResult resource = resourceApi.openForRead(fileUri);
                                 io = resource.inputStream;
                                 mimeType = resource.mimeType;


### PR DESCRIPTION
<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist is intended as a quick reference, for complete details please see our Contributor Guidelines:

http://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->

### Platforms affected

Android

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

Regression from https://github.com/apache/cordova-plugin-file/commit/99ca43990c0bcdf19645367a27f1f8106d1be71d

Code strips out the `file://` protocol for what used to be used by File APIs, but in 8.1.1 that was changed to use CordvaResourceApi which expects an actual valid URI.

### Description
<!-- Describe your changes in detail -->

If the uri object has no scheme set, then set it to the `file` scheme.

### Testing
<!-- Please describe in detail how you tested your changes. -->

paramedic tests passes.
Testing by using camera plugin to capture an image, resolve the `file://` uri and attempt to set an image tag `src` attribute to the `fileEntry.toURL()` result.

### Checklist

- [x] I've run the tests to see all new and existing tests pass
- [x] I added automated test coverage as appropriate for this change
- [x] Commit is prefixed with `(platform)` if this change only applies to one platform (e.g. `(android)`)
- [x] If this Pull Request resolves an issue, I linked to the issue in the text above (and used the correct [keyword to close issues using keywords](https://help.github.com/articles/closing-issues-using-keywords/))
- [x] I've updated the documentation if necessary
