### PR TITLE
fix(ios): Entry.toURL() to produce DOM-usable uri when using scheme-hosted webview

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -182,6 +182,9 @@ to config.xml in order for the application to find previously stored files.
         <source-file src="src/ios/CDVAssetLibraryFilesystem.m" />
 
         <!-- ios specific file apis -->
+        <js-module src="www/ios/Entry.js" name="iosEntry">
+            <merges target="Entry" />
+        </js-module>
         <js-module src="www/ios/FileSystem.js" name="iosFileSystem">
             <merges target="FileSystem" />
         </js-module>

--- a/tests/tests.js
+++ b/tests/tests.js
@@ -135,7 +135,7 @@ exports.defineAutoTests = function () {
             success = success || function () {};
             error = error || failed.bind(null, success, 'deleteEntry failed.');
 
-            window.resolveLocalFileSystemURL(root.toURL() + '/' + name, function (entry) {
+            window.resolveLocalFileSystemURL(root.nativeURL + '/' + name, function (entry) {
                 if (entry.isDirectory === true) {
                     entry.removeRecursively(success, error);
                 } else {
@@ -321,7 +321,7 @@ exports.defineAutoTests = function () {
                         deleteEntry(fileName, done);
                     };
                     createFile(fileName, function (entry) {
-                        window.resolveLocalFileSystemURL(entry.toURL(), win, failed.bind(null, done, 'window.resolveLocalFileSystemURL - Error resolving file URL: ' + entry.toURL()));
+                        window.resolveLocalFileSystemURL(entry.nativeURL, win, failed.bind(null, done, 'window.resolveLocalFileSystemURL - Error resolving file URL: ' + entry.nativeURL));
                     }, failed.bind(null, done, 'createFile - Error creating file: ' + fileName), failed.bind(null, done, 'createFile - Error creating file: ' + fileName));
                 });
 
@@ -338,7 +338,7 @@ exports.defineAutoTests = function () {
                         deleteEntry(fileName, done);
                     };
                     createFile(fileName, function (entry) {
-                        const entryURL = entry.toURL() + '/';
+                        const entryURL = entry.nativeURL + '/';
                         window.resolveLocalFileSystemURL(entryURL, win, failed.bind(null, done, 'window.resolveLocalFileSystemURL - Error resolving file URL: ' + entryURL));
                     }, failed.bind(null, done, 'createFile - Error creating file: ' + fileName), failed.bind(null, done, 'createFile - Error creating file: ' + fileName));
                 });
@@ -357,7 +357,7 @@ exports.defineAutoTests = function () {
                     };
                     function gotDirectory (entry) {
                         // lookup file system entry
-                        window.resolveLocalFileSystemURL(entry.toURL(), win, failed.bind(null, done, 'window.resolveLocalFileSystemURL - Error resolving directory URL: ' + entry.toURL()));
+                        window.resolveLocalFileSystemURL(entry.nativeURL, win, failed.bind(null, done, 'window.resolveLocalFileSystemURL - Error resolving directory URL: ' + entry.nativeURL));
                     }
                     createDirectory(fileName, gotDirectory, failed.bind(null, done, 'createDirectory - Error creating directory: ' + fileName), failed.bind(null, done, 'createDirectory - Error creating directory: ' + fileName));
                 });
@@ -376,7 +376,7 @@ exports.defineAutoTests = function () {
                     };
                     function gotDirectory (entry) {
                         // lookup file system entry
-                        let entryURL = entry.toURL();
+                        let entryURL = entry.nativeURL;
                         entryURL = entryURL.substring(0, entryURL.length - 1);
                         window.resolveLocalFileSystemURL(entryURL, win, failed.bind(null, done, 'window.resolveLocalFileSystemURL - Error resolving directory URL: ' + entryURL));
                     }
@@ -412,12 +412,12 @@ exports.defineAutoTests = function () {
                     };
                     // create a new file entry
                     createFile(fileName, function (entry) {
-                        window.resolveLocalFileSystemURL(entry.toURL() + '?1234567890', win, failed.bind(null, done, 'window.resolveLocalFileSystemURL - Error resolving file URI: ' + entry.toURL()));
+                        window.resolveLocalFileSystemURL(entry.nativeURL + '?1234567890', win, failed.bind(null, done, 'window.resolveLocalFileSystemURL - Error resolving file URI: ' + entry.nativeURL));
                     }, failed.bind(null, done, 'createFile - Error creating file: ' + fileName));
                 });
 
                 it('file.spec.11 should error (NOT_FOUND_ERR) when resolving (non-existent) invalid file name', function (done) {
-                    const fileName = joinURL(root.toURL(), 'this.is.not.a.valid.file.txt');
+                    const fileName = joinURL(root.nativeURL, 'this.is.not.a.valid.file.txt');
                     const fail = function (error) {
                         expect(error).toBeDefined();
                         if (isChrome) {
@@ -488,7 +488,7 @@ exports.defineAutoTests = function () {
                     expect(entry.removeRecursively).toBeDefined();
                     done();
                 };
-                window.resolveLocalFileSystemURL(root.toURL(), win, failed.bind(null, done, 'window.resolveLocalFileSystemURL - Error resolving file URI: ' + root.toURL()));
+                window.resolveLocalFileSystemURL(root.nativeURL, win, failed.bind(null, done, 'window.resolveLocalFileSystemURL - Error resolving file URI: ' + root.nativeURL));
             });
         });
 
@@ -684,7 +684,7 @@ exports.defineAutoTests = function () {
                 function getDir (dirEntry) {
                     expect(dirEntry.filesystem).toBeDefined();
                     expect(dirEntry.filesystem).toBe(root.filesystem);
-                    const dirURI = dirEntry.toURL();
+                    const dirURI = dirEntry.nativeURL;
                     // now encode URI and try to resolve
                     window.resolveLocalFileSystemURL(dirURI, win, failed.bind(null, done, 'window.resolveLocalFileSystemURL - getDir function - Error resolving directory: ' + dirURI));
                 }
@@ -3355,7 +3355,7 @@ exports.defineAutoTests = function () {
             /* These specs verify that paths with parent references i("..") in them
              * work correctly, and do not cause the application to crash.
              */
-            it('file.spec.110 should not throw exception resolving parent refefences', function (done) {
+            it('file.spec.110 should not throw exception resolving parent references', function (done) {
                 /* This is a direct copy of file.spec.9, with the filename changed, * as reported in CB-5721.
                  */
                 const fileName = 'resolve.file.uri';
@@ -3364,12 +3364,12 @@ exports.defineAutoTests = function () {
                 createDirectory(dirName, function () {
                     createFile(dirName + '/../' + fileName, function (entry) {
                         // lookup file system entry
-                        window.resolveLocalFileSystemURL(entry.toURL(), function (fileEntry) {
+                        window.resolveLocalFileSystemURL(entry.nativeURL, function (fileEntry) {
                             expect(fileEntry).toBeDefined();
                             expect(fileEntry.name).toCanonicallyMatch(fileName);
                             // cleanup
                             deleteEntry(fileName, done);
-                        }, failed.bind(null, done, 'window.resolveLocalFileSystemURL - Error resolving URI: ' + entry.toURL()));
+                        }, failed.bind(null, done, 'window.resolveLocalFileSystemURL - Error resolving URI: ' + entry.nativeURL));
                     }, failed.bind(null, done, 'createFile - Error creating file: ../' + fileName));
                 }, failed.bind(null, done, 'createDirectory - Error creating directory: ' + dirName));
             });
@@ -3442,6 +3442,8 @@ exports.defineAutoTests = function () {
                 // From Cordova-Android 10.x, app content is served from the "https" scheme by default
                 // The paramedic plugin changes the scheme to http to avoid ssl.
                 pathExpect = 'http://';
+            } else if (cordova.platformId === 'ios') {
+                pathExpect = 'app://';
             } else if (isChrome) {
                 pathExpect = 'filesystem:http://';
             }
@@ -3502,7 +3504,7 @@ exports.defineAutoTests = function () {
                 const fileName = 'native.resolve.uri';
                 // create a new file entry
                 createFile(fileName, function (entry) {
-                    resolveLocalFileSystemURL(entry.toURL(), function (entry) { // eslint-disable-line no-undef
+                    resolveLocalFileSystemURL(entry.nativeURL, function (entry) { // eslint-disable-line no-undef
                         expect(entry.toNativeURL).toBeDefined();
                         expect(entry.name).toCanonicallyMatch(fileName);
                         expect(typeof entry.toNativeURL).toBe('function');
@@ -3512,7 +3514,7 @@ exports.defineAutoTests = function () {
                         expect(nativeURL.substring(nativeURL.length - fileName.length)).toEqual(fileName);
                         // cleanup
                         deleteEntry(fileName, done);
-                    }, failed.bind(null, done, 'resolveLocalFileSystemURL - Error resolving file URL: ' + entry.toURL()));
+                    }, failed.bind(null, done, 'resolveLocalFileSystemURL - Error resolving file URL: ' + entry.nativeURL));
                 }, failed.bind(null, done, 'createFile - Error creating file: ' + fileName));
             });
         });
@@ -3553,7 +3555,10 @@ exports.defineAutoTests = function () {
                 });
             });
 
-            it('file.spec.121 should resolve native URLs returned by API', function (done) {
+            // TODO: .toNativeURL() / .toURL() were repurposed at some point so return a DOM-usable url
+            // these urls are not resolvable as they expect file:// or content://schemes
+            // I think these tests can simply be removed.
+            xit('file.spec.121 should resolve native URLs returned by API', function (done) {
                 const fileName = 'native.resolve.uri1';
                 // create a new file entry
                 createFile(fileName, function (entry) {
@@ -3566,7 +3571,10 @@ exports.defineAutoTests = function () {
                 }, failed.bind(null, done, 'createFile - Error creating file: ' + fileName));
             });
 
-            it('file.spec.122 should resolve native URLs returned by API with localhost', function (done) {
+            // TODO: .toNativeURL() / .toURL() were repurposed at some point so return a DOM-usable url
+            // these urls are not resolvable as they expect file:// or content://schemes
+            // I think these tests can simply be removed.
+            xit('file.spec.122 should resolve native URLs returned by API with localhost', function (done) {
                 const fileName = 'native.resolve.uri2';
                 // create a new file entry
                 createFile(fileName, function (entry) {
@@ -3580,7 +3588,10 @@ exports.defineAutoTests = function () {
                 }, failed.bind(null, done, 'createFile - Error creating file: ' + fileName));
             });
 
-            it('file.spec.123 should resolve native URLs returned by API with query string', function (done) {
+            // TODO: .toNativeURL() / .toURL() were repurposed at some point so return a DOM-usable url
+            // these urls are not resolvable as they expect file:// or content://schemes
+            // I think these tests can simply be removed.
+            xit('file.spec.123 should resolve native URLs returned by API with query string', function (done) {
                 const fileName = 'native.resolve.uri3';
                 // create a new file entry
                 createFile(fileName, function (entry) {
@@ -3594,7 +3605,10 @@ exports.defineAutoTests = function () {
                 }, failed.bind(null, done, 'createFile - Error creating file: ' + fileName));
             });
 
-            it('file.spec.124 should resolve native URLs returned by API with localhost and query string', function (done) {
+            // TODO: .toNativeURL() / .toURL() were repurposed at some point so return a DOM-usable url
+            // these urls are not resolvable as they expect file:// or content://schemes
+            // I think these tests can simply be removed.
+            xit('file.spec.124 should resolve native URLs returned by API with localhost and query string', function (done) {
                 const fileName = 'native.resolve.uri4';
                 // create a new file entry
                 createFile(fileName, function (entry) {

--- a/www/ios/Entry.js
+++ b/www/ios/Entry.js
@@ -26,8 +26,8 @@ module.exports = {
    * <audio> tag. If that is not possible, construct a http(s)://(localhost) URL.
    */
     toURL: function () {
-        return window.location.origin.includes('file://')
-            ? this.nativeURL
-            : window.WkWebView.convertFilePath(this.nativeURL);
+        return (window.WkWebView && window.WkWebView.convertFilePath)
+            ? window.WkWebView.convertFilePath(this.nativeURL)
+            : this.nativeURL;
     }
 };

--- a/www/ios/Entry.js
+++ b/www/ios/Entry.js
@@ -1,0 +1,33 @@
+/*
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *
+*/
+
+module.exports = {
+    /**
+   * Return a URL that can be used to identify this entry.
+   * Use a URL that can be used to as the src attribute of a <video> or
+   * <audio> tag. If that is not possible, construct a http(s)://(localhost) URL.
+   */
+    toURL: function () {
+        return window.location.origin.includes('file://')
+            ? this.nativeURL
+            : window.WkWebView.convertFilePath(this.nativeURL);
+    }
+};


### PR DESCRIPTION

<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist is intended as a quick reference, for complete details please see our Contributor Guidelines:

http://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->

### Platforms affected

iOS

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

Entry's `toURL()` method is intended to produce a DOM-usable URIs.
This works as intended on Android.

On iOS however, it only worked if the app was configured to be in a `file://` hosted webview. If the webview was configured to use schemes, it would still produce a `file://` uri which is not usable in the DOM.

I believe this can be considered a patch, for `file://` hosted users, this should behave the same as before. For scheme-hosted users, the `.toURL()` will return a different URI, but the original format didn't work as intended. If the user were using `.toURL()` for another purpose, then this could be considered a breaking change?

### Description
<!-- Describe your changes in detail -->

Mimick how Android solves this issue, by creating an ios specific `Entry.js` file which contains a `toURL` method override with iOS specific logic.

### Testing
<!-- Please describe in detail how you tested your changes. -->

Manually tested with and without the `scheme` preference to observe `toURL()` producing `file://` urls while in `file://` hosted mode, or `app://` uris if the app is using `scheme` preference.

Also tested completely custom schemes using:

```xml
<preference name="scheme" value="myapp" />
<preference name="hostname" value="appname" />
```

and observing URIs such as `myapp://appname/_app_file_/var/mobile/Containers/Data/Application/84D10AA8-302C-4295-8690-54F4C4EA9BB2/tmp/cdv_photo_1730252303.jpg`.

Confirmed that in both cases, the produced URIs are usable in the DOM to properly load image assets, for example.

### Unit Test Refactoring

Now that `.toURL()` returns a `app://` uri instead of a `file://` uri, it broke several tests that used `.toURL()` to resolve a file entry. `app://` uris return an encoding error, presumably because there is no filesystem implementation to handle the scheme.

Most cases I've replaced the usage of `.toURL()` with `.nativeURL` to make the test pass. However there is a handful of tests that was specifically calling `.toNativeURL()` to test the resolve method and `.toNativeURL()` simply calls `.toURL()` with a deprecation notice. I think these tests can be complete as I believe they are an out-dated practice. `.toNativeURL()` is also deprecated, but I've kept them for now, just disabled them until we decide what to do.

### Checklist

- [x] I've run the tests to see all new and existing tests pass
- [x] I added automated test coverage as appropriate for this change
- [x] Commit is prefixed with `(platform)` if this change only applies to one platform (e.g. `(android)`)
- [x] If this Pull Request resolves an issue, I linked to the issue in the text above (and used the correct [keyword to close issues using keywords](https://help.github.com/articles/closing-issues-using-keywords/))
- [x] I've updated the documentation if necessary
