### PR TITLE
fix(test): file.spec.131 moveTo may fail due to read order assumption

### DIFF
--- a/tests/tests.js
+++ b/tests/tests.js
@@ -1941,8 +1941,12 @@ exports.defineAutoTests = function () {
                                     directoryReader.readEntries(function successRead (entries) {
                                         expect(entries.length).toBe(2);
                                         if (!isChrome) {
-                                            expect(entries[0].name).toBe(srcDirNestedFirst);
-                                            expect(entries[1].name).toBe(srcDirNestedSecond);
+                                            // Directory read order is undefined on some platforms, therefore we cannot assume order
+                                            // So we will start with an expected list and iterate over the entries and test to see if they
+                                            // are in our expectation list. When found we will remove them. At the end, our expectation list
+                                            // should be empty.
+                                            const expected = [srcDirNestedFirst, srcDirNestedSecond];
+                                            expect(entries.map((entry) => entry.name)).toEqual(jasmine.arrayWithExactContents(expected));
                                         }
                                         deleteEntry(dstDir, done);
                                     }, failed.bind(null, done, 'Error getting entries from: ' + transferredDirectory));


### PR DESCRIPTION
<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist is intended as a quick reference, for complete details please see our Contributor Guidelines:

http://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->

### Platforms affected

tests

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

On iOS (and I think any file api I've ever used), reading directories does not define any particular order of files. The iOS implementation uses [contentsOfDirectoryAtPath:error:](https://developer.apple.com/documentation/foundation/nsfilemanager/1414584-contentsofdirectoryatpath) which states:

> The order of the files in the returned array is undefined.

While this test does not appear to be failing actively on GH actions, it was failing for me locally due to the expectation assuming that they will be in a particular order.

### Description
<!-- Describe your changes in detail -->

Reworked the test so that it will scan for each expected value and keep track which ones it has found.
Assertions of the expected item count remains.
Asserts that each item is found.

### Testing
<!-- Please describe in detail how you tested your changes. -->

Ran mobilespec locally on iOS.

### Checklist

- [x] I've run the tests to see all new and existing tests pass
- [x] I added automated test coverage as appropriate for this change
- [x] Commit is prefixed with `(platform)` if this change only applies to one platform (e.g. `(android)`)
- [x] If this Pull Request resolves an issue, I linked to the issue in the text above (and used the correct [keyword to close issues using keywords](https://help.github.com/articles/closing-issues-using-keywords/))
- [x] I've updated the documentation if necessary
