### PR TITLE
chore: bump to next major 9.0.0-dev, raise `cordovaDependencies`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cordova-plugin-file",
-  "version": "8.1.4-dev",
+  "version": "9.0.0-dev",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cordova-plugin-file",
-      "version": "8.1.4-dev",
+      "version": "9.0.0-dev",
       "license": "Apache-2.0",
       "devDependencies": {
         "@cordova/eslint-config": "^5.0.0"

--- a/package-lock.json
+++ b/package-lock.json
@@ -23,6 +23,11 @@
             "cordova-android": ">=12.0.0"
           },
           "9.0.0": {
+            "cordova-android": ">=13.0.0",
+            "cordova-ios": ">=6.2.0",
+            "cordova": ">=11.0.0"
+          },
+          "10.0.0": {
             "cordova": ">100"
           }
         }

--- a/package.json
+++ b/package.json
@@ -43,6 +43,11 @@
         "cordova-android": ">=12.0.0"
       },
       "9.0.0": {
+        "cordova-android": ">=13.0.0",
+        "cordova-ios": ">=6.2.0",
+        "cordova": ">=11.0.0"
+      },
+      "10.0.0": {
         "cordova": ">100"
       }
     }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cordova-plugin-file",
-  "version": "8.1.4-dev",
+  "version": "9.0.0-dev",
   "description": "Cordova File Plugin",
   "types": "./types/index.d.ts",
   "cordova": {

--- a/plugin.xml
+++ b/plugin.xml
@@ -21,7 +21,7 @@
 <plugin xmlns="http://apache.org/cordova/ns/plugins/1.0"
 xmlns:android="http://schemas.android.com/apk/res/android"
            id="cordova-plugin-file"
-      version="8.1.4-dev">
+      version="9.0.0-dev">
     <name>File</name>
     <description>Cordova File Plugin</description>
     <license>Apache 2.0</license>

--- a/tests/package-lock.json
+++ b/tests/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cordova-plugin-file-tests",
-  "version": "8.1.4-dev",
+  "version": "9.0.0-dev",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cordova-plugin-file-tests",
-      "version": "8.1.4-dev",
+      "version": "9.0.0-dev",
       "license": "Apache-2.0"
     }
   }

--- a/tests/package.json
+++ b/tests/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cordova-plugin-file-tests",
-  "version": "8.1.4-dev",
+  "version": "9.0.0-dev",
   "description": "",
   "cordova": {
     "id": "cordova-plugin-file-tests",

--- a/tests/plugin.xml
+++ b/tests/plugin.xml
@@ -21,7 +21,7 @@
 <plugin xmlns="http://apache.org/cordova/ns/plugins/1.0"
     xmlns:android="http://schemas.android.com/apk/res/android"
     id="cordova-plugin-file-tests"
-    version="8.1.4-dev">
+    version="9.0.0-dev">
 
     <name>Cordova File Plugin Tests</name>
     <license>Apache 2.0</license>


### PR DESCRIPTION
<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist is intended as a quick reference, for complete details please see our Contributor Guidelines:

http://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->

### Platforms affected

All

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

- The next release should be a major to remove deprecated platforms, see #644 
- `cordova-ios` and `cordova` was not added to `cordovaDependencies`. cordova-ios 6.2.0 and cordova 11.0.0 should be a good starting point
- cordova-android raised from 12.0.0. to 13.0.0

### Description
<!-- Describe your changes in detail -->



### Testing
<!-- Please describe in detail how you tested your changes. -->



### Checklist

- [ ] I've run the tests to see all new and existing tests pass
- [ ] I added automated test coverage as appropriate for this change
- [ ] Commit is prefixed with `(platform)` if this change only applies to one platform (e.g. `(android)`)
- [ ] If this Pull Request resolves an issue, I linked to the issue in the text above (and used the correct [keyword to close issues using keywords](https://help.github.com/articles/closing-issues-using-keywords/))
- [ ] I've updated the documentation if necessary
