### PR TITLE
fix(ios): Use `CDVSettingsDictionary` instead of `NSMutableDictionary`, small refactoring

### DIFF
--- a/src/ios/CDVFile.h
+++ b/src/ios/CDVFile.h
@@ -20,6 +20,16 @@
 #import <Foundation/Foundation.h>
 #import <Cordova/CDVPlugin.h>
 
+
+#ifndef __CORDOVA_8_0_0
+#import <Cordova/NSDictionary+CordovaPreferences.h>
+// cordova-ios 8 introduced CDVSettingsDictionary, which should be used
+// instead of NSDictionary+CordovaPreferences
+// For cordova-ios 7 and earlier, we create a type alias for NSDictionary to CDVSettingsDictionary,
+// so that a symbolic "CDVSettingsDictionary" can be used in these older cordova-ios versions.
+typedef NSDictionary CDVSettingsDictionary;
+#endif
+
 extern NSString* const kCDVAssetsLibraryPrefix;
 extern NSString* const kCDVFilesystemURLPrefix;
 

--- a/src/ios/CDVFile.m
+++ b/src/ios/CDVFile.m
@@ -238,18 +238,15 @@ NSString* const kCDVFilesystemURLPrefix = @"cdvfile";
     }
 }
 
-- (NSArray *)getExtraFileSystemsPreference:(UIViewController *)vc
+- (NSArray *)getExtraFileSystemsPreference
 {
-    NSString *filesystemsStr = nil;
-    if([self.viewController isKindOfClass:[CDVViewController class]]) {
-        CDVViewController *vc = (CDVViewController *)self.viewController;
-        NSDictionary *settings = [vc settings];
-        filesystemsStr = [settings[@"iosextrafilesystems"] lowercaseString];
+    NSString *extraFileSystems = [[self.viewController.settings objectForKey:@"iosextrafilesystems"] lowercaseString];
+
+    if (!extraFileSystems) {
+        extraFileSystems = @"library,library-nosync,documents,documents-nosync,cache,bundle,root";
     }
-    if (!filesystemsStr) {
-        filesystemsStr = @"library,library-nosync,documents,documents-nosync,cache,bundle,root";
-    }
-    return [filesystemsStr componentsSeparatedByString:@","];
+
+    return [extraFileSystems componentsSeparatedByString:@","];
 }
 
 - (void)makeNonSyncable:(NSString*)path {
@@ -322,17 +319,11 @@ NSString* const kCDVFilesystemURLPrefix = @"cdvfile";
     self.rootDocsPath = [paths objectAtIndex:0];
     self.appDocsPath = [self.rootDocsPath stringByAppendingPathComponent:@"files"];
 
+    NSString *persistentFileLocation = [[self.viewController.settings objectForKey:@"iospersistentfilelocation"] lowercaseString];
 
-    NSString *location = nil;
-    if([self.viewController isKindOfClass:[CDVViewController class]]) {
-        CDVViewController *vc = (CDVViewController *)self.viewController;
-        NSMutableDictionary *settings = vc.settings;
-        location = [[settings objectForKey:@"iospersistentfilelocation"] lowercaseString];
-    }
-    if (location == nil) {
-        // Compatibilty by default (if the config preference is not set, or
-        // if we're not embedded in a CDVViewController somehow.)
-        location = @"compatibility";
+    // Compatibilty by default (if the config preference is not set)
+    if (persistentFileLocation == nil) {
+        persistentFileLocation = @"compatibility";
     }
 
     NSError *error;
@@ -344,7 +335,7 @@ NSString* const kCDVFilesystemURLPrefix = @"cdvfile";
     } else {
         NSLog(@"Unable to create temporary directory: %@", error);
     }
-    if ([location isEqualToString:@"library"]) {
+    if ([persistentFileLocation isEqualToString:@"library"]) {
         if ([[NSFileManager defaultManager] createDirectoryAtPath:self.appLibraryPath
                                       withIntermediateDirectories:YES
                                                        attributes:nil
@@ -353,7 +344,7 @@ NSString* const kCDVFilesystemURLPrefix = @"cdvfile";
         } else {
             NSLog(@"Unable to create library directory: %@", error);
         }
-    } else if ([location isEqualToString:@"compatibility"]) {
+    } else if ([persistentFileLocation isEqualToString:@"compatibility"]) {
         /*
          *  Fall-back to compatibility mode -- this is the logic implemented in
          *  earlier versions of this plugin, and should be maintained here so
@@ -368,7 +359,7 @@ NSString* const kCDVFilesystemURLPrefix = @"cdvfile";
     }
     [self registerFilesystem:[[CDVAssetLibraryFilesystem alloc] initWithName:@"assets-library"]];
 
-    [self registerExtraFileSystems:[self getExtraFileSystemsPreference:self.viewController]
+    [self registerExtraFileSystems:[self getExtraFileSystemsPreference]
                   fromAvailableSet:[self getAvailableFileSystems]];
 
 }


### PR DESCRIPTION
<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist is intended as a quick reference, for complete details please see our Contributor Guidelines:

http://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->

### Platforms affected

iOS

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

- self.viewController.settings was assigned to a local variable typed `NSMutableDictionary`. ` self.viewController.settings` is used directly.
- Add type alias NSDictionary to CDVSettingsDictionary when using cordova-ios 7 and older
- Don't check if self.viewController is kind of class CDVViewController. CDVViewController was introduced in Cordova 2.0.0.
- Refactored method `getExtraFileSystemsPreference`

### Description
<!-- Describe your changes in detail -->



### Testing
<!-- Please describe in detail how you tested your changes. -->



### Checklist

- [ ] I've run the tests to see all new and existing tests pass
- [ ] I added automated test coverage as appropriate for this change
- [ ] Commit is prefixed with `(platform)` if this change only applies to one platform (e.g. `(android)`)
- [ ] If this Pull Request resolves an issue, I linked to the issue in the text above (and used the correct [keyword to close issues using keywords](https://help.github.com/articles/closing-issues-using-keywords/))
- [ ] I've updated the documentation if necessary
