### PR TITLE
fix(ios): remove deprecated `CDVPluginResult.associatedObject` usage in `CDVFile`

### DIFF
--- a/src/ios/CDVFile.m
+++ b/src/ios/CDVFile.m
@@ -863,11 +863,10 @@ NSString* const kCDVFilesystemURLPrefix = @"cdvfile";
         [fs readFileAtURL:localURI start:start end:end callback:^(NSData* data, NSString* mimeType, CDVFileError errorCode) {
             CDVPluginResult* result = nil;
             if (data != nil) {
-                NSString* str = [[NSString alloc] initWithBytesNoCopy:(void*)[data bytes] length:[data length] encoding:NSUTF8StringEncoding freeWhenDone:NO];
+                NSString* str = [[NSString alloc] initWithData:data encoding:NSUTF8StringEncoding];
                 // Check that UTF8 conversion did not fail.
                 if (str != nil) {
                     result = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK messageAsString:str];
-                    result.associatedObject = data;
                 } else {
                     errorCode = ENCODING_ERR;
                 }
@@ -962,9 +961,8 @@ NSString* const kCDVFilesystemURLPrefix = @"cdvfile";
         [fs readFileAtURL:localURI start:start end:end callback:^(NSData* data, NSString* mimeType, CDVFileError errorCode) {
             CDVPluginResult* result = nil;
             if (data != nil) {
-                NSString* payload = [[NSString alloc] initWithBytesNoCopy:(void*)[data bytes] length:[data length] encoding:NSASCIIStringEncoding freeWhenDone:NO];
+                NSString* payload = [[NSString alloc] initWithData:data encoding:NSASCIIStringEncoding];
                 result = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK messageAsString:payload];
-                result.associatedObject = data;
             } else {
                 result = [CDVPluginResult resultWithStatus:CDVCommandStatus_IO_EXCEPTION messageAsInt:errorCode];
             }


### PR DESCRIPTION
<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist is intended as a quick reference, for complete details please see our Contributor Guidelines:

http://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->

### Platforms affected

iOS

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

Fix XCode deprecation warnings about assigning `CDVPluginResult.associatedObject` which is deprecated since cordova-ios 8

- replace `initWithBytesNoCopy` string creation with `initWithData:encoding:` in iOS read paths
- remove `result.associatedObject = data` assignments in `readAsText` and `readAsBinaryString`
- keep behavior the same while eliminating Cordova iOS 8 deprecation warnings

Generated-By: GPT-5.3-Codex

### Description
<!-- Describe your changes in detail -->



### Testing
<!-- Please describe in detail how you tested your changes. -->



### Checklist

- [ ] I've run the tests to see all new and existing tests pass
- [ ] I added automated test coverage as appropriate for this change
- [ ] Commit is prefixed with `(platform)` if this change only applies to one platform (e.g. `(android)`)
- [ ] If this Pull Request resolves an issue, I linked to the issue in the text above (and used the correct [keyword to close issues using keywords](https://help.github.com/articles/closing-issues-using-keywords/))
- [ ] I've updated the documentation if necessary
